### PR TITLE
Juno gui()

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -24,7 +24,7 @@ plot(rand(10), fmt = :png)
 
 ### Juno / Atom
 
-Plots are shown in the Atom PlotPane when possible, either when returned to the console or to an inline code block.  The REPL behavior (i.e. opening a standalone window) can be acheived by setting `ENV["PLOTS_USE_ATOM_PLOTPANE"] = "false"` before loading Plots.
+Plots are shown in the Atom PlotPane when possible, either when returned to the console or to an inline code block. At any time, the plot can be opened in a standalone window using the `gui()` command. The default behavior can be switched to match the REPL behavior (i.e. opening a standalone window) by setting `ENV["PLOTS_USE_ATOM_PLOTPANE"] = "false"` before loading Plots.
 
 Note that javascript-based libraries (for example: PlotlyJS) cannot be shown in the PlotPane due to issues within Atom's internals.
 


### PR DESCRIPTION
It should be more clear that `gui()` still exists in Juno, but it's not the default behavior. I think it read before that the only way to get the standalone plot window (when in Juno) would be to change the environment variable. I know it's seems redundant with what's above, but I think this will stop all confusion.