### PR TITLE
note the output formats

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -54,7 +54,7 @@ These are treated as separate backends, though they share much of the code and u
 as the required javascript is bundled with Plots.  It can create inline plots in IJulia, or open standalone browser windows when run from the Julia REPL.
 
 `plotlyjs()` is the preferred option, and taps into the great functionality of Spencer Lyon's PlotlyJS.jl.  Inline IJulia plots can be updated from any cell... something that
-makes this backend stand out.  From the Julia REPL, it taps into Blink.jl and Electron to plot within a standalone GUI window... also very cool.
+makes this backend stand out.  From the Julia REPL, it taps into Blink.jl and Electron to plot within a standalone GUI window... also very cool. Also, PlotlyJS supports saving the output to more formats than Plotly, such as EPS and PDF, and thus is the recommended version of Plotly for developing publication-quality figures.
 
 ![](examples/img/plotlyjs/plotlyjs_example_28.png)
 


### PR DESCRIPTION
Note in the docs that Plotly allows for more output formats to help users make the right choice when needing to save vector graphics.