### PR TITLE
Fix layout commands

### DIFF
--- a/docs/examples/pgfplots.md
+++ b/docs/examples/pgfplots.md
@@ -138,7 +138,7 @@ Use the `layout` keyword, and optionally the convenient `@layout` macro to gener
 
 
 ```julia
-l = @layout([a{0.1h},b [c,d e]])
+l = @layout([a{0.1h};b [c;d e]])
 plot(randn(100,5),layout=l,t=[:line :histogram :scatter :steppre :bar],leg=false,ticks=nothing,border=false)
 ```
 

--- a/docs/examples/plotlyjs.md
+++ b/docs/examples/plotlyjs.md
@@ -179,7 +179,7 @@ Use the `layout` keyword, and optionally the convenient `@layout` macro to gener
 
 
 ```julia
-l = @layout([a{0.1h},b [c,d e]])
+l = @layout([a{0.1h};b [c;d e]])
 plot(randn(100,5),layout=l,t=[:line :histogram :scatter :steppre :bar],leg=false,ticks=nothing,border=false)
 ```
 

--- a/docs/examples/pyplot.md
+++ b/docs/examples/pyplot.md
@@ -191,7 +191,7 @@ Use the `layout` keyword, and optionally the convenient `@layout` macro to gener
 
 
 ```julia
-l = @layout([a{0.1h},b [c,d e]])
+l = @layout([a{0.1h};b [c;d e]])
 plot(randn(100,5),layout=l,t=[:line :histogram :scatter :steppre :bar],leg=false,ticks=nothing,border=false)
 ```
 


### PR DESCRIPTION
The layout commands in the examples don't parse. This should be `;`.