### PR TITLE
Insert a link to attributes and move tutorial up

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,16 @@
 
-# Intro to Plots in Julia
+# Plots - powerful convenience for visualization in Julia
 
 **Author: Thomas Breloff (@tbreloff)**
+
+To get started, [see the tutorial](/tutorial).
+
+Almost everything in Plots is done by specifying plot [attributes](/attributes)
+
+Tap into the extensive visualization functionality enabled by the [Plots ecosystem](/ecosystem), and easily build your own complex graphics components with [recipes](/recipes).
+
+
+## Intro to Plots in Julia
 
 Data visualization has a complicated history.  Plotting software makes trade-offs between features and simplicity, speed and beauty, and a static and dynamic interface. Some packages make a display and never change it, while others make updates in real-time.
 
@@ -17,11 +26,7 @@ My goals with the package are:
 - **Lightweight**.  Very few dependencies, since backends are loaded and initialized dynamically.
 - **Smart**.  It's not quite AGI, but Plots should figure out what you **want** it to do... not just what you **tell** it.
 
-To get started, [see the tutorial](/tutorial).
-
 Use the [preprocessing pipeline](/pipeline) in Plots to describe your visualization completely before it calls the backend code.  This preprocessing maintains modularity and allows for efficient separation of front end code, algorithms, and backend graphics.
-
-Tap into the extensive visualization functionality enabled by the [Plots ecosystem](/ecosystem), and easily build your own complex graphics components with [recipes](/recipes).
 
 Please add wishlist items, bugs, or any other comments/questions to the [issues list](https://github.com/tbreloff/Plots.jl/issues), and [join the conversation on gitter](https://gitter.im/tbreloff/Plots.jl).
 


### PR DESCRIPTION
Makes it easier to find the important attribute table. See also https://github.com/JuliaPlots/Plots.jl/issues/995