### PR TITLE
Maybe fix link for editing docs?

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ site_name: 'Plots'
 site_author: 'Thomas Breloff'
 
 repo_name: 'GitHub'
-repo_url: 'https://github.com/JuliaPlots/Plots.jl'
+repo_url: 'https://github.com/JuliaPlots/PlotDocs.jl'
 
 copyright: 'Copyright &copy; 2015-2016 Thomas Breloff'
 


### PR DESCRIPTION
Inspired by
https://discourse.julialang.org/t/where-is-actual-development-in-plotting/6224/96?u=tim.holy. Not that I think the "Edit on GitHub" link for the JuliaImages docs has ever netted much :frowning: 

I am not sure how `mkdocs.yml` really works, didn't build locally (though presumably this affects deployment which I can't test), etc. So feel free to close if you think this is broken.