### PR TITLE
Only use 90 columns per line in examples

### DIFF
--- a/docs/src/examples/gr.md
+++ b/docs/src/examples/gr.md
@@ -20,7 +20,7 @@ plot(Plots.fakedata(50,5),w=3)
 Plot function pair (x(u), y(u)).
 
 ```julia
-plot(sin,(x->begin 
+plot(sin,(x->begin
             sin(2x)
         end),0,2π,line=4,leg=false,fill=(0,:orange))
 ```
@@ -41,7 +41,11 @@ scatter!(y,zcolor=abs(y - 0.5),m=(:heat,0.8,stroke(1,:green)),ms=10 * abs(y - 0.
 
 ### Global
 
-Change the guides/background/limits/ticks.  Convenience args `xaxis` and `yaxis` allow you to pass a tuple or value which will be mapped to the relevant args automatically.  The `xaxis` below will be replaced with `xlabel` and `xlims` args automatically during the preprocessing step. You can also use shorthand functions: `title!`, `xaxis!`, `yaxis!`, `xlabel!`, `ylabel!`, `xlims!`, `ylims!`, `xticks!`, `yticks!`
+Change the guides/background/limits/ticks.  Convenience args `xaxis` and `yaxis` allow
+you to pass a tuple or value which will be mapped to the relevant args automatically.
+The `xaxis` below will be replaced with `xlabel` and `xlims` args automatically during
+the preprocessing step. You can also use shorthand functions: `title!`, `xaxis!`,
+`yaxis!`, `xlabel!`, `ylabel!`, `xlims!`, `ylims!`, `xticks!`, `yticks!`
 
 ```julia
 y = rand(20,3)
@@ -87,7 +91,7 @@ plot(rand(100) / 3,reg=true,fill=(0,:green))
 
 ![](img/gr/gr_example_8.png)
 
-### 
+###
 
 and add to it later.
 
@@ -126,7 +130,7 @@ plot(x,y,line=(linetypes,3),lab=map(string,linetypes),ms=15)
 
 
 ```julia
-styles = (filter((s->begin 
+styles = (filter((s->begin
             s in Plots.supported_styles()
         end),[:solid,:dash,:dot,:dashdot,:dashdotdot]))'
 n = length(styles)
@@ -141,7 +145,7 @@ plot(y,line=(5,styles),label=map(string,styles))
 
 
 ```julia
-markers = (filter((m->begin 
+markers = (filter((m->begin
             m in Plots.supported_markers()
         end),Plots._shape_keys))'
 n = length(markers)
@@ -194,7 +198,7 @@ plot(Plots.fakedata(100,10),layout=4,palette=[:grays :blues :heat :lightrainbow]
 
 ![](img/gr/gr_example_17.png)
 
-### 
+###
 
 
 
@@ -207,7 +211,9 @@ plot!(Plots.fakedata(100,10))
 
 ### Open/High/Low/Close
 
-Create an OHLC chart.  Pass in a list of (open,high,low,close) tuples as your `y` argument.  This uses recipes to first convert the tuples to OHLC objects, and subsequently create a :path series with the appropriate line segments.
+Create an OHLC chart.  Pass in a list of (open,high,low,close) tuples as your `y`
+argument.  This uses recipes to first convert the tuples to OHLC objects, and
+subsequently create a :path series with the appropriate line segments.
 
 ```julia
 n = 20
@@ -215,7 +221,8 @@ hgt = rand(n) + 1
 bot = randn(n)
 openpct = rand(n)
 closepct = rand(n)
-y = OHLC[(openpct[i] * hgt[i] + bot[i],bot[i] + hgt[i],bot[i],closepct[i] * hgt[i] + bot[i]) for i = 1:n]
+y = OHLC[(openpct[i] * hgt[i] + bot[i],bot[i] + hgt[i],bot[i],closepct[i] * hgt[i] +
+          bot[i]) for i = 1:n]
 ohlc(y)
 ```
 
@@ -223,38 +230,51 @@ ohlc(y)
 
 ### Annotations
 
-The `annotations` keyword is used for text annotations in data-coordinates.  Pass in a tuple (x,y,text) or a vector of annotations.  `annotate!(ann)` is shorthand for `plot!(; annotation=ann)`.  Series annotations are used for annotating individual data points.  They require only the annotation... x/y values are computed.  A `PlotText` object can be build with the method `text(string, attr...)`, which wraps font and color attributes.
+The `annotations` keyword is used for text annotations in data-coordinates.  Pass in a
+tuple (x,y,text) or a vector of annotations.  `annotate!(ann)` is shorthand for `plot!(;
+annotation=ann)`.  Series annotations are used for annotating individual data points.
+They require only the annotation... x/y values are computed.  A `PlotText` object can be
+build with the method `text(string, attr...)`, which wraps font and color attributes.
 
 ```julia
 y = rand(10)
 plot(y,annotations=(3,y[3],text("this is #3",:left)),leg=false)
-annotate!([(5,y[5],text("this is #5",16,:red,:center)),(10,y[10],text("this is #10",:right,20,"courier"))])
-scatter!(linspace(2,8,6),rand(6),marker=(50,0.2,:orange),series_annotations=["series","annotations","map","to","series",text("data",:green)])
+annotate!([(5,y[5],text("this is #5",16,:red,:center)),
+          (10,y[10],text("this is #10",:right,20,"courier"))])
+scatter!(linspace(2,8,6),rand(6),marker=(50,0.2,:orange),
+         series_annotations=["series","annotations","map","to","series",
+                             text("data",:green)])
 ```
 
 ![](img/gr/gr_example_20.png)
 
 ### Custom Markers
 
-A `Plots.Shape` is a light wrapper around vertices of a polygon.  For supported backends, pass arbitrary polygons as the marker shapes.  Note: The center is (0,0) and the size is expected to be rougly the area of the unit circle.
+A `Plots.Shape` is a light wrapper around vertices of a polygon.  For supported backends,
+pass arbitrary polygons as the marker shapes.  Note: The center is (0,0) and the size is
+expected to be rougly the area of the unit circle.
 
 ```julia
-verts = [(-1.0,1.0),(-1.28,0.6),(-0.2,-1.4),(0.2,-1.4),(1.28,0.6),(1.0,1.0),(-1.0,1.0),(-0.2,-0.6),(0.0,-0.2),(-0.4,0.6),(1.28,0.6),(0.2,-1.4),(-0.2,-1.4),(0.6,0.2),(-0.2,0.2),(0.0,-0.2),(0.2,0.2),(-0.2,-0.6)]
+verts = [(-1.0,1.0),(-1.28,0.6),(-0.2,-1.4),(0.2,-1.4),(1.28,0.6),(1.0,1.0),
+         (-1.0,1.0),(-0.2,-0.6),(0.0,-0.2),(-0.4,0.6),(1.28,0.6),(0.2,-1.4),
+         (-0.2,-1.4),(0.6,0.2),(-0.2,0.2),(0.0,-0.2),(0.2,0.2),(-0.2,-0.6)]
 x = 0.1:0.2:0.9
 y = 0.7 * rand(5) + 0.15
-plot(x,y,line=(3,:dash,:lightblue),marker=(Shape(verts),30,RGBA(0,0,0,0.2)),bg=:pink,fg=:darkblue,xlim=(0,1),ylim=(0,1),leg=false)
+plot(x,y,line=(3,:dash,:lightblue),marker=(Shape(verts),30,RGBA(0,0,0,0.2)),
+     bg=:pink,fg=:darkblue,xlim=(0,1),ylim=(0,1),leg=false)
 ```
 
 ![](img/gr/gr_example_21.png)
 
 ### Contours
 
-Any value for fill works here.  We first build a filled contour from a function, then an unfilled contour from a matrix.
+Any value for fill works here.  We first build a filled contour from a function, then an
+unfilled contour from a matrix.
 
 ```julia
 x = 1:0.5:20
 y = 1:0.5:10
-f(x,y) = begin 
+f(x,y) = begin
         (3x + y ^ 2) * abs(sin(x) + cos(y))
     end
 X = repmat(x',length(y),1)
@@ -300,7 +320,7 @@ plot!(zeros(n),zeros(n),1:n,w=10)
 
 
 ```julia
-group = rand(map((i->begin 
+group = rand(map((i->begin
                     "group $(i)"
                 end),1:4),100)
 plot(rand(100),layout=@layout([a b;c]),group=group,linetype=[:bar :scatter :steppre])
@@ -349,7 +369,9 @@ The `layout` macro can be used to create an animation with subplots.
 
 ```julia
 l = @layout([[a;b] c])
-p = plot(plot([sin,cos],1,leg=false),scatter([atan,cos],1,leg=false),plot(log,1,xlims=(1,10π),ylims=(0,5),leg=false),layout=l)
+p = plot(plot([sin,cos],1,leg=false),
+         scatter([atan,cos],1,leg=false),
+         plot(log,1,xlims=(1,10π),ylims=(0,5),leg=false),layout=l)
 anim = Animation()
 for x = linspace(1,10π,100)
     plot(push!(p,x,Float64[sin(x),cos(x),atan(x),cos(x),log(x)]))

--- a/docs/src/examples/inspectdr.md
+++ b/docs/src/examples/inspectdr.md
@@ -20,7 +20,7 @@ plot(Plots.fakedata(50,5),w=3)
 Plot function pair (x(u), y(u)).
 
 ```julia
-plot(sin,(x->begin 
+plot(sin,(x->begin
             sin(2x)
         end),0,2π,line=4,leg=false,fill=(0,:orange))
 ```
@@ -29,7 +29,11 @@ plot(sin,(x->begin
 
 ### Global
 
-Change the guides/background/limits/ticks.  Convenience args `xaxis` and `yaxis` allow you to pass a tuple or value which will be mapped to the relevant args automatically.  The `xaxis` below will be replaced with `xlabel` and `xlims` args automatically during the preprocessing step. You can also use shorthand functions: `title!`, `xaxis!`, `yaxis!`, `xlabel!`, `ylabel!`, `xlims!`, `ylims!`, `xticks!`, `yticks!`
+Change the guides/background/limits/ticks.  Convenience args `xaxis` and `yaxis` allow
+you to pass a tuple or value which will be mapped to the relevant args automatically.
+The `xaxis` below will be replaced with `xlabel` and `xlims` args automatically during
+the preprocessing step. You can also use shorthand functions: `title!`, `xaxis!`,
+`yaxis!`, `xlabel!`, `ylabel!`, `xlims!`, `ylims!`, `xticks!`, `yticks!`
 
 ```julia
 y = rand(20,3)
@@ -44,7 +48,12 @@ yaxis!("YLABEL",:log10)
 
 ### Arguments
 
-Plot multiple series with different numbers of points.  Mix arguments that apply to all series (marker/markersize) with arguments unique to each series (colors).  Special arguments `line`, `marker`, and `fill` will automatically figure out what arguments to set (for example, we are setting the `linestyle`, `linewidth`, and `color` arguments with `line`.)  Note that we pass a matrix of colors, and this applies the colors to each series.
+Plot multiple series with different numbers of points.  Mix arguments that apply to all
+series (marker/markersize) with arguments unique to each series (colors).  Special
+arguments `line`, `marker`, and `fill` will automatically figure out what arguments to
+set (for example, we are setting the `linestyle`, `linewidth`, and `color` arguments with
+`line`.)  Note that we pass a matrix of colors, and this applies the colors to each
+series.
 
 ```julia
 ys = Vector[rand(10),rand(20)]
@@ -53,7 +62,7 @@ plot(ys,color=[:black :orange],line=(:dot,4),marker=([:hex :d],12,0.8,stroke(3,:
 
 ![](img/inspectdr/inspectdr_example_7.png)
 
-### 
+###
 
 and add to it later.
 
@@ -82,7 +91,7 @@ plot(x,y,line=(linetypes,3),lab=map(string,linetypes),ms=15)
 
 
 ```julia
-styles = (filter((s->begin 
+styles = (filter((s->begin
             s in Plots.supported_styles()
         end),[:solid,:dash,:dot,:dashdot,:dashdotdot]))'
 n = length(styles)
@@ -97,7 +106,7 @@ plot(y,line=(5,styles),label=map(string,styles))
 
 
 ```julia
-markers = (filter((m->begin 
+markers = (filter((m->begin
             m in Plots.supported_markers()
         end),Plots._shape_keys))'
 n = length(markers)
@@ -130,27 +139,31 @@ histogram(randn(1000),nbins=20)
 
 ### Subplots
 
-Use the `layout` keyword, and optionally the convenient `@layout` macro to generate arbitrarily complex subplot layouts.
+Use the `layout` keyword, and optionally the convenient `@layout` macro to generate
+arbitrarily complex subplot layouts.
 
 
 ```julia
 l = @layout([a{0.1h};b [c;d e]])
-plot(randn(100,5),layout=l,t=[:line :histogram :scatter :steppre :bar],leg=false,ticks=nothing,border=false)
+plot(randn(100,5),layout=l,t=[:line :histogram :scatter :steppre :bar],
+     leg=false,ticks=nothing,border=false)
 ```
 
 ![](img/inspectdr/inspectdr_example_16.png)
 
 ### Adding to subplots
 
-Note here the automatic grid layout, as well as the order in which new series are added to the plots.
+Note here the automatic grid layout, as well as the order in which new series are added
+to the plots.
 
 ```julia
-plot(Plots.fakedata(100,10),layout=4,palette=[:grays :blues :heat :lightrainbow],bg_inside=[:orange :pink :darkblue :black])
+plot(Plots.fakedata(100,10),layout=4,palette=[:grays :blues :heat :lightrainbow],
+     bg_inside=[:orange :pink :darkblue :black])
 ```
 
 ![](img/inspectdr/inspectdr_example_17.png)
 
-### 
+###
 
 
 
@@ -163,7 +176,9 @@ plot!(Plots.fakedata(100,10))
 
 ### Open/High/Low/Close
 
-Create an OHLC chart.  Pass in a list of (open,high,low,close) tuples as your `y` argument.  This uses recipes to first convert the tuples to OHLC objects, and subsequently create a :path series with the appropriate line segments.
+Create an OHLC chart.  Pass in a list of (open,high,low,close) tuples as your `y`
+argument.  This uses recipes to first convert the tuples to OHLC objects, and
+subsequently create a :path series with the appropriate line segments.
 
 ```julia
 n = 20
@@ -171,7 +186,8 @@ hgt = rand(n) + 1
 bot = randn(n)
 openpct = rand(n)
 closepct = rand(n)
-y = OHLC[(openpct[i] * hgt[i] + bot[i],bot[i] + hgt[i],bot[i],closepct[i] * hgt[i] + bot[i]) for i = 1:n]
+y = OHLC[(openpct[i] * hgt[i] + bot[i],bot[i] + hgt[i],bot[i],closepct[i] * hgt[i] +
+          bot[i]) for i = 1:n]
 ohlc(y)
 ```
 
@@ -179,26 +195,38 @@ ohlc(y)
 
 ### Annotations
 
-The `annotations` keyword is used for text annotations in data-coordinates.  Pass in a tuple (x,y,text) or a vector of annotations.  `annotate!(ann)` is shorthand for `plot!(; annotation=ann)`.  Series annotations are used for annotating individual data points.  They require only the annotation... x/y values are computed.  A `PlotText` object can be build with the method `text(string, attr...)`, which wraps font and color attributes.
+The `annotations` keyword is used for text annotations in data-coordinates.  Pass in a
+tuple (x,y,text) or a vector of annotations.  `annotate!(ann)` is shorthand for `plot!(;
+annotation=ann)`.  Series annotations are used for annotating individual data points.
+They require only the annotation... x/y values are computed.  A `PlotText` object can be
+build with the method `text(string, attr...)`, which wraps font and color attributes.
 
 ```julia
 y = rand(10)
 plot(y,annotations=(3,y[3],text("this is #3",:left)),leg=false)
-annotate!([(5,y[5],text("this is #5",16,:red,:center)),(10,y[10],text("this is #10",:right,20,"courier"))])
-scatter!(linspace(2,8,6),rand(6),marker=(50,0.2,:orange),series_annotations=["series","annotations","map","to","series",text("data",:green)])
+annotate!([(5,y[5],text("this is #5",16,:red,:center)),
+          (10,y[10],text("this is #10",:right,20,"courier"))])
+scatter!(linspace(2,8,6),rand(6),marker=(50,0.2,:orange),
+         series_annotations=["series","annotations","map","to","series",
+                             text("data",:green)])
 ```
 
 ![](img/inspectdr/inspectdr_example_20.png)
 
 ### Custom Markers
 
-A `Plots.Shape` is a light wrapper around vertices of a polygon.  For supported backends, pass arbitrary polygons as the marker shapes.  Note: The center is (0,0) and the size is expected to be rougly the area of the unit circle.
+A `Plots.Shape` is a light wrapper around vertices of a polygon.  For supported backends,
+pass arbitrary polygons as the marker shapes.  Note: The center is (0,0) and the size is
+expected to be rougly the area of the unit circle.
 
 ```julia
-verts = [(-1.0,1.0),(-1.28,0.6),(-0.2,-1.4),(0.2,-1.4),(1.28,0.6),(1.0,1.0),(-1.0,1.0),(-0.2,-0.6),(0.0,-0.2),(-0.4,0.6),(1.28,0.6),(0.2,-1.4),(-0.2,-1.4),(0.6,0.2),(-0.2,0.2),(0.0,-0.2),(0.2,0.2),(-0.2,-0.6)]
+verts =[(-1.0,1.0),(-1.28,0.6),(-0.2,-1.4),(0.2,-1.4),(1.28,0.6),(1.0,1.0),
+        (-1.0,1.0),(-0.2,-0.6),(0.0,-0.2),(-0.4,0.6),(1.28,0.6),(0.2,-1.4),
+        (-0.2,-1.4),(0.6,0.2),(-0.2,0.2),(0.0,-0.2),(0.2,0.2),(-0.2,-0.6)]
 x = 0.1:0.2:0.9
 y = 0.7 * rand(5) + 0.15
-plot(x,y,line=(3,:dash,:lightblue),marker=(Shape(verts),30,RGBA(0,0,0,0.2)),bg=:pink,fg=:darkblue,xlim=(0,1),ylim=(0,1),leg=false)
+plot(x,y,line=(3,:dash,:lightblue),marker=(Shape(verts),30,RGBA(0,0,0,0.2)),
+     bg=:pink,fg=:darkblue,xlim=(0,1),ylim=(0,1),leg=false)
 ```
 
 ![](img/inspectdr/inspectdr_example_21.png)
@@ -208,7 +236,7 @@ plot(x,y,line=(3,:dash,:lightblue),marker=(Shape(verts),30,RGBA(0,0,0,0.2)),bg=:
 
 
 ```julia
-group = rand(map((i->begin 
+group = rand(map((i->begin
                     "group $(i)"
                 end),1:4),100)
 plot(rand(100),layout=@layout([a b;c]),group=group,linetype=[:bar :scatter :steppre])

--- a/docs/src/examples/pgfplots.md
+++ b/docs/src/examples/pgfplots.md
@@ -29,7 +29,11 @@ plot(sin,(x->begin
 
 ### Global
 
-Change the guides/background/limits/ticks.  Convenience args `xaxis` and `yaxis` allow you to pass a tuple or value which will be mapped to the relevant args automatically.  The `xaxis` below will be replaced with `xlabel` and `xlims` args automatically during the preprocessing step. You can also use shorthand functions: `title!`, `xaxis!`, `yaxis!`, `xlabel!`, `ylabel!`, `xlims!`, `ylims!`, `xticks!`, `yticks!`
+Change the guides/background/limits/ticks.  Convenience args `xaxis` and `yaxis` allow
+you to pass a tuple or value which will be mapped to the relevant args automatically.
+The `xaxis` below will be replaced with `xlabel` and `xlims` args automatically during
+the preprocessing step. You can also use shorthand functions: `title!`, `xaxis!`,
+`yaxis!`, `xlabel!`, `ylabel!`, `xlims!`, `ylims!`, `xticks!`, `yticks!`
 
 ```julia
 y = rand(20,3)
@@ -44,7 +48,9 @@ yaxis!("YLABEL",:log10)
 
 ### Extra LaTeX packages
 
-You can add LaTeX formating with support for additional LaTeX packages with `LaTeXStrings.jl` and `PGFPlots.pushPGFPlotsPreamble`. For example, if we add the package `amssymb`, we can get Blackboard bold symbols with the `\mathbb` control sequence:
+You can add LaTeX formating with support for additional LaTeX packages with
+`LaTeXStrings.jl` and `PGFPlots.pushPGFPlotsPreamble`. For example, if we add the package
+`amssymb`, we can get Blackboard bold symbols with the `\mathbb` control sequence:
 
 ```julia
 using LaTeXStrings
@@ -54,7 +60,12 @@ ylabel!(L"$\mathbb E[f(x)]$")
 
 ### Arguments
 
-Plot multiple series with different numbers of points.  Mix arguments that apply to all series (marker/markersize) with arguments unique to each series (colors).  Special arguments `line`, `marker`, and `fill` will automatically figure out what arguments to set (for example, we are setting the `linestyle`, `linewidth`, and `color` arguments with `line`.)  Note that we pass a matrix of colors, and this applies the colors to each series.
+Plot multiple series with different numbers of points.  Mix arguments that apply to all
+series (marker/markersize) with arguments unique to each series (colors).  Special
+arguments `line`, `marker`, and `fill` will automatically figure out what arguments to
+set (for example, we are setting the `linestyle`, `linewidth`, and `color` arguments with
+`line`.)  Note that we pass a matrix of colors, and this applies the colors to each
+series.
 
 ```julia
 ys = Vector[rand(10),rand(20)]
@@ -144,22 +155,27 @@ histogram(randn(1000),nbins=20)
 
 ### Subplots
 
-Use the `layout` keyword, and optionally the convenient `@layout` macro to generate arbitrarily complex subplot layouts.
+Use the `layout` keyword, and optionally the convenient `@layout` macro to generate
+arbitrarily complex subplot layouts.
 
 
 ```julia
 l = @layout([a{0.1h};b [c;d e]])
-plot(randn(100,5),layout=l,t=[:line :histogram :scatter :steppre :bar],leg=false,ticks=nothing,border=false)
+plot(randn(100,5),layout=l,
+     t=[:line :histogram :scatter :steppre :bar],leg=false,ticks=nothing,border=false)
 ```
 
 ![](img/pgfplots/pgfplots_example_16.png)
 
 ### Adding to subplots
 
-Note here the automatic grid layout, as well as the order in which new series are added to the plots.
+Note here the automatic grid layout, as well as the order in which new series are added
+to the plots.
 
 ```julia
-plot(Plots.fakedata(100,10),layout=4,palette=[:grays :blues :heat :lightrainbow],bg_inside=[:orange :pink :darkblue :black])
+plot(Plots.fakedata(100,10),layout=4,
+     palette=[:grays :blues :heat :lightrainbow],
+     bg_inside=[:orange :pink :darkblue :black])
 ```
 
 ![](img/pgfplots/pgfplots_example_17.png)
@@ -177,7 +193,9 @@ plot!(Plots.fakedata(100,10))
 
 ### Open/High/Low/Close
 
-Create an OHLC chart.  Pass in a list of (open,high,low,close) tuples as your `y` argument.  This uses recipes to first convert the tuples to OHLC objects, and subsequently create a :path series with the appropriate line segments.
+Create an OHLC chart.  Pass in a list of (open,high,low,close) tuples as your `y`
+argument.  This uses recipes to first convert the tuples to OHLC objects, and
+subsequently create a :path series with the appropriate line segments.
 
 ```julia
 n = 20
@@ -185,7 +203,8 @@ hgt = rand(n) + 1
 bot = randn(n)
 openpct = rand(n)
 closepct = rand(n)
-y = OHLC[(openpct[i] * hgt[i] + bot[i],bot[i] + hgt[i],bot[i],closepct[i] * hgt[i] + bot[i]) for i = 1:n]
+y = OHLC[(openpct[i] * hgt[i] + bot[i],bot[i] + hgt[i],bot[i],closepct[i] * hgt[i] +
+          bot[i]) for i = 1:n]
 ohlc(y)
 ```
 
@@ -193,26 +212,38 @@ ohlc(y)
 
 ### Annotations
 
-The `annotations` keyword is used for text annotations in data-coordinates.  Pass in a tuple (x,y,text) or a vector of annotations.  `annotate!(ann)` is shorthand for `plot!(; annotation=ann)`.  Series annotations are used for annotating individual data points.  They require only the annotation... x/y values are computed.  A `PlotText` object can be build with the method `text(string, attr...)`, which wraps font and color attributes.
+The `annotations` keyword is used for text annotations in data-coordinates.  Pass in a
+tuple (x,y,text) or a vector of annotations.  `annotate!(ann)` is shorthand for `plot!(;
+annotation=ann)`.  Series annotations are used for annotating individual data points.
+They require only the annotation... x/y values are computed.  A `PlotText` object can be
+build with the method `text(string, attr...)`, which wraps font and color attributes.
 
 ```julia
 y = rand(10)
 plot(y,annotations=(3,y[3],text("this is #3",:left)),leg=false)
-annotate!([(5,y[5],text("this is #5",16,:red,:center)),(10,y[10],text("this is #10",:right,20,"courier"))])
-scatter!(linspace(2,8,6),rand(6),marker=(50,0.2,:orange),series_annotations=["series","annotations","map","to","series",text("data",:green)])
+annotate!([(5,y[5],text("this is #5",16,:red,:center)),
+          (10,y[10],text("this is #10",:right,20,"courier"))])
+scatter!(linspace(2,8,6),rand(6),marker=(50,0.2,:orange),
+         series_annotations=["series","annotations","map","to","series",
+                             text("data",:green)])
 ```
 
 ![](img/pgfplots/pgfplots_example_20.png)
 
 ### Custom Markers
 
-A `Plots.Shape` is a light wrapper around vertices of a polygon.  For supported backends, pass arbitrary polygons as the marker shapes.  Note: The center is (0,0) and the size is expected to be rougly the area of the unit circle.
+A `Plots.Shape` is a light wrapper around vertices of a polygon.  For supported backends,
+pass arbitrary polygons as the marker shapes.  Note: The center is (0,0) and the size is
+expected to be rougly the area of the unit circle.
 
 ```julia
-verts = [(-1.0,1.0),(-1.28,0.6),(-0.2,-1.4),(0.2,-1.4),(1.28,0.6),(1.0,1.0),(-1.0,1.0),(-0.2,-0.6),(0.0,-0.2),(-0.4,0.6),(1.28,0.6),(0.2,-1.4),(-0.2,-1.4),(0.6,0.2),(-0.2,0.2),(0.0,-0.2),(0.2,0.2),(-0.2,-0.6)]
+verts =[(-1.0,1.0),(-1.28,0.6),(-0.2,-1.4),(0.2,-1.4),(1.28,0.6),(1.0,1.0),(-1.0,1.0),
+        (-0.2,-0.6),(0.0,-0.2),(-0.4,0.6),(1.28,0.6),(0.2,-1.4),(-0.2,-1.4),(0.6,0.2),
+        (-0.2,0.2),(0.0,-0.2),(0.2,0.2),(-0.2,-0.6)]
 x = 0.1:0.2:0.9
 y = 0.7 * rand(5) + 0.15
-plot(x,y,line=(3,:dash,:lightblue),marker=(Shape(verts),30,RGBA(0,0,0,0.2)),bg=:pink,fg=:darkblue,xlim=(0,1),ylim=(0,1),leg=false)
+plot(x,y,line=(3,:dash,:lightblue),marker=(Shape(verts),30,RGBA(0,0,0,0.2)),bg=:pink,
+     fg=:darkblue,xlim=(0,1),ylim=(0,1),leg=false)
 ```
 
 ![](img/pgfplots/pgfplots_example_21.png)
@@ -262,7 +293,9 @@ plot(Θ,r,proj=:polar,m=2)
 
 
 ```julia
-plot(rand(100,6),layout=@layout([a b;c]),title=["A" "B" "C"],title_location=:left,left_margin=[20mm 0mm],bottom_margin=50px,xrotation=60)
+plot(rand(100,6),layout=@layout([a b;c]),
+     title=["A" "B" "C"],title_location=:left,
+     left_margin=[20mm 0mm],bottom_margin=50px,xrotation=60)
 ```
 
 ![](img/pgfplots/pgfplots_example_29.png)

--- a/docs/src/examples/plotlyjs.md
+++ b/docs/src/examples/plotlyjs.md
@@ -20,7 +20,7 @@ plot(Plots.fakedata(50,5),w=3)
 Plot function pair (x(u), y(u)).
 
 ```julia
-plot(sin,(x->begin 
+plot(sin,(x->begin
             sin(2x)
         end),0,2π,line=4,leg=false,fill=(0,:orange))
 ```
@@ -29,19 +29,26 @@ plot(sin,(x->begin
 
 ### Colors
 
-Access predefined palettes (or build your own with the `colorscheme` method).  Line/marker colors are auto-generated from the plot's palette, unless overridden.  Set the `z` argument to turn on series gradients.
+Access predefined palettes (or build your own with the `colorscheme` method).
+Line/marker colors are auto-generated from the plot's palette, unless overridden.  Set
+the `z` argument to turn on series gradients.
 
 ```julia
 y = rand(100)
 plot(0:10:100,rand(11,4),lab="lines",w=3,palette=:grays,fill=0,α=0.6)
-scatter!(y,zcolor=abs(y - 0.5),m=(:heat,0.8,stroke(1,:green)),ms=10 * abs(y - 0.5) + 4,lab="grad")
+scatter!(y,zcolor=abs(y - 0.5),
+         m=(:heat,0.8,stroke(1,:green)),ms=10 * abs(y - 0.5) + 4,lab="grad")
 ```
 
 ![](img/plotlyjs/plotlyjs_example_4.png)
 
 ### Global
 
-Change the guides/background/limits/ticks.  Convenience args `xaxis` and `yaxis` allow you to pass a tuple or value which will be mapped to the relevant args automatically.  The `xaxis` below will be replaced with `xlabel` and `xlims` args automatically during the preprocessing step. You can also use shorthand functions: `title!`, `xaxis!`, `yaxis!`, `xlabel!`, `ylabel!`, `xlims!`, `ylims!`, `xticks!`, `yticks!`
+Change the guides/background/limits/ticks.  Convenience args `xaxis` and `yaxis` allow
+you to pass a tuple or value which will be mapped to the relevant args automatically.
+The `xaxis` below will be replaced with `xlabel` and `xlims` args automatically during
+the preprocessing step. You can also use shorthand functions: `title!`, `xaxis!`,
+`yaxis!`, `xlabel!`, `ylabel!`, `xlims!`, `ylims!`, `xticks!`, `yticks!`
 
 ```julia
 y = rand(20,3)
@@ -56,7 +63,12 @@ yaxis!("YLABEL",:log10)
 
 ### Arguments
 
-Plot multiple series with different numbers of points.  Mix arguments that apply to all series (marker/markersize) with arguments unique to each series (colors).  Special arguments `line`, `marker`, and `fill` will automatically figure out what arguments to set (for example, we are setting the `linestyle`, `linewidth`, and `color` arguments with `line`.)  Note that we pass a matrix of colors, and this applies the colors to each series.
+Plot multiple series with different numbers of points.  Mix arguments that apply to all
+series (marker/markersize) with arguments unique to each series (colors).  Special
+arguments `line`, `marker`, and `fill` will automatically figure out what arguments to
+set (for example, we are setting the `linestyle`, `linewidth`, and `color` arguments with
+`line`.)  Note that we pass a matrix of colors, and this applies the colors to each
+series.
 
 ```julia
 ys = Vector[rand(10),rand(20)]
@@ -75,7 +87,7 @@ plot(rand(100) / 3,reg=true,fill=(0,:green))
 
 ![](img/plotlyjs/plotlyjs_example_8.png)
 
-### 
+###
 
 and add to it later.
 
@@ -114,7 +126,7 @@ plot(x,y,line=(linetypes,3),lab=map(string,linetypes),ms=15)
 
 
 ```julia
-styles = (filter((s->begin 
+styles = (filter((s->begin
             s in Plots.supported_styles()
         end),[:solid,:dash,:dot,:dashdot,:dashdotdot]))'
 n = length(styles)
@@ -129,7 +141,7 @@ plot(y,line=(5,styles),label=map(string,styles))
 
 
 ```julia
-markers = (filter((m->begin 
+markers = (filter((m->begin
             m in Plots.supported_markers()
         end),Plots._shape_keys))'
 n = length(markers)
@@ -162,27 +174,32 @@ histogram(randn(1000),nbins=20)
 
 ### Subplots
 
-Use the `layout` keyword, and optionally the convenient `@layout` macro to generate arbitrarily complex subplot layouts.
+Use the `layout` keyword, and optionally the convenient `@layout` macro to generate
+arbitrarily complex subplot layouts.
 
 
 ```julia
 l = @layout([a{0.1h};b [c;d e]])
-plot(randn(100,5),layout=l,t=[:line :histogram :scatter :steppre :bar],leg=false,ticks=nothing,border=false)
+plot(randn(100,5),layout=l,
+     t=[:line :histogram :scatter :steppre :bar],leg=false,ticks=nothing,border=false)
 ```
 
 ![](img/plotlyjs/plotlyjs_example_16.png)
 
 ### Adding to subplots
 
-Note here the automatic grid layout, as well as the order in which new series are added to the plots.
+Note here the automatic grid layout, as well as the order in which new series are added
+to the plots.
 
 ```julia
-plot(Plots.fakedata(100,10),layout=4,palette=[:grays :blues :heat :lightrainbow],bg_inside=[:orange :pink :darkblue :black])
+plot(Plots.fakedata(100,10),layout=4,
+     palette=[:grays :blues :heat :lightrainbow],
+     bg_inside=[:orange :pink :darkblue :black])
 ```
 
 ![](img/plotlyjs/plotlyjs_example_17.png)
 
-### 
+###
 
 
 
@@ -195,7 +212,9 @@ plot!(Plots.fakedata(100,10))
 
 ### Open/High/Low/Close
 
-Create an OHLC chart.  Pass in a list of (open,high,low,close) tuples as your `y` argument.  This uses recipes to first convert the tuples to OHLC objects, and subsequently create a :path series with the appropriate line segments.
+Create an OHLC chart.  Pass in a list of (open,high,low,close) tuples as your `y`
+argument.  This uses recipes to first convert the tuples to OHLC objects, and
+subsequently create a :path series with the appropriate line segments.
 
 ```julia
 n = 20
@@ -203,7 +222,8 @@ hgt = rand(n) + 1
 bot = randn(n)
 openpct = rand(n)
 closepct = rand(n)
-y = OHLC[(openpct[i] * hgt[i] + bot[i],bot[i] + hgt[i],bot[i],closepct[i] * hgt[i] + bot[i]) for i = 1:n]
+y = OHLC[(openpct[i] * hgt[i] + bot[i],bot[i] + hgt[i],bot[i],closepct[i] * hgt[i] +
+          bot[i]) for i = 1:n]
 ohlc(y)
 ```
 
@@ -211,13 +231,20 @@ ohlc(y)
 
 ### Annotations
 
-The `annotations` keyword is used for text annotations in data-coordinates.  Pass in a tuple (x,y,text) or a vector of annotations.  `annotate!(ann)` is shorthand for `plot!(; annotation=ann)`.  Series annotations are used for annotating individual data points.  They require only the annotation... x/y values are computed.  A `PlotText` object can be build with the method `text(string, attr...)`, which wraps font and color attributes.
+The `annotations` keyword is used for text annotations in data-coordinates.  Pass in a
+tuple (x,y,text) or a vector of annotations.  `annotate!(ann)` is shorthand for `plot!(;
+annotation=ann)`.  Series annotations are used for annotating individual data points.
+They require only the annotation... x/y values are computed.  A `PlotText` object can be
+build with the method `text(string, attr...)`, which wraps font and color attributes.
 
 ```julia
 y = rand(10)
 plot(y,annotations=(3,y[3],text("this is #3",:left)),leg=false)
-annotate!([(5,y[5],text("this is #5",16,:red,:center)),(10,y[10],text("this is #10",:right,20,"courier"))])
-scatter!(linspace(2,8,6),rand(6),marker=(50,0.2,:orange),series_annotations=["series","annotations","map","to","series",text("data",:green)])
+annotate!([(5,y[5],text("this is #5",16,:red,:center)),
+          (10,y[10],text("this is #10",:right,20,"courier"))])
+scatter!(linspace(2,8,6),rand(6),marker=(50,0.2,:orange),
+         series_annotations=["series","annotations","map","to","series",
+                             text("data",:green)])
 ```
 
 ![](img/plotlyjs/plotlyjs_example_20.png)
@@ -227,10 +254,13 @@ scatter!(linspace(2,8,6),rand(6),marker=(50,0.2,:orange),series_annotations=["se
 A `Plots.Shape` is a light wrapper around vertices of a polygon.  For supported backends, pass arbitrary polygons as the marker shapes.  Note: The center is (0,0) and the size is expected to be rougly the area of the unit circle.
 
 ```julia
-verts = [(-1.0,1.0),(-1.28,0.6),(-0.2,-1.4),(0.2,-1.4),(1.28,0.6),(1.0,1.0),(-1.0,1.0),(-0.2,-0.6),(0.0,-0.2),(-0.4,0.6),(1.28,0.6),(0.2,-1.4),(-0.2,-1.4),(0.6,0.2),(-0.2,0.2),(0.0,-0.2),(0.2,0.2),(-0.2,-0.6)]
+verts = [(-1.0,1.0),(-1.28,0.6),(-0.2,-1.4),(0.2,-1.4),(1.28,0.6),(1.0,1.0),(-1.0,1.0),
+         (-0.2,-0.6),(0.0,-0.2),(-0.4,0.6),(1.28,0.6),(0.2,-1.4),(-0.2,-1.4),(0.6,0.2),
+         (-0.2,0.2),(0.0,-0.2),(0.2,0.2),(-0.2,-0.6)]
 x = 0.1:0.2:0.9
 y = 0.7 * rand(5) + 0.15
-plot(x,y,line=(3,:dash,:lightblue),marker=(Shape(verts),30,RGBA(0,0,0,0.2)),bg=:pink,fg=:darkblue,xlim=(0,1),ylim=(0,1),leg=false)
+plot(x,y,line=(3,:dash,:lightblue),marker=(Shape(verts),30,RGBA(0,0,0,0.2)),bg=:pink,
+     fg=:darkblue,xlim=(0,1),ylim=(0,1),leg=false)
 ```
 
 ![](img/plotlyjs/plotlyjs_example_21.png)
@@ -242,7 +272,7 @@ Any value for fill works here.  We first build a filled contour from a function,
 ```julia
 x = 1:0.5:20
 y = 1:0.5:10
-f(x,y) = begin 
+f(x,y) = begin
         (3x + y ^ 2) * abs(sin(x) + cos(y))
     end
 X = repmat(x',length(y),1)
@@ -288,7 +318,7 @@ plot!(zeros(n),zeros(n),1:n,w=10)
 
 
 ```julia
-group = rand(map((i->begin 
+group = rand(map((i->begin
                     "group $(i)"
                 end),1:4),100)
 plot(rand(100),layout=@layout([a b;c]),group=group,linetype=[:bar :scatter :steppre])

--- a/docs/src/examples/pyplot.md
+++ b/docs/src/examples/pyplot.md
@@ -20,7 +20,7 @@ plot(Plots.fakedata(50,5),w=3)
 Plot function pair (x(u), y(u)).
 
 ```julia
-plot(sin,(x->begin 
+plot(sin,(x->begin
             sin(2x)
         end),0,2π,line=4,leg=false,fill=(0,:orange))
 ```
@@ -29,19 +29,26 @@ plot(sin,(x->begin
 
 ### Colors
 
-Access predefined palettes (or build your own with the `colorscheme` method).  Line/marker colors are auto-generated from the plot's palette, unless overridden.  Set the `z` argument to turn on series gradients.
+Access predefined palettes (or build your own with the `colorscheme` method).
+Line/marker colors are auto-generated from the plot's palette, unless overridden.  Set
+the `z` argument to turn on series gradients.
 
 ```julia
 y = rand(100)
 plot(0:10:100,rand(11,4),lab="lines",w=3,palette=:grays,fill=0,α=0.6)
-scatter!(y,zcolor=abs(y - 0.5),m=(:heat,0.8,stroke(1,:green)),ms=10 * abs(y - 0.5) + 4,lab="grad")
+scatter!(y,zcolor=abs(y - 0.5),
+         m=(:heat,0.8,stroke(1,:green)),ms=10 * abs(y - 0.5) + 4,lab="grad")
 ```
 
 ![](img/pyplot/pyplot_example_4.png)
 
 ### Global
 
-Change the guides/background/limits/ticks.  Convenience args `xaxis` and `yaxis` allow you to pass a tuple or value which will be mapped to the relevant args automatically.  The `xaxis` below will be replaced with `xlabel` and `xlims` args automatically during the preprocessing step. You can also use shorthand functions: `title!`, `xaxis!`, `yaxis!`, `xlabel!`, `ylabel!`, `xlims!`, `ylims!`, `xticks!`, `yticks!`
+Change the guides/background/limits/ticks.  Convenience args `xaxis` and `yaxis` allow
+you to pass a tuple or value which will be mapped to the relevant args automatically.
+The `xaxis` below will be replaced with `xlabel` and `xlims` args automatically during
+the preprocessing step. You can also use shorthand functions: `title!`, `xaxis!`,
+`yaxis!`, `xlabel!`, `ylabel!`, `xlims!`, `ylims!`, `xticks!`, `yticks!`
 
 ```julia
 y = rand(20,3)
@@ -56,7 +63,12 @@ yaxis!("YLABEL",:log10)
 
 ### Arguments
 
-Plot multiple series with different numbers of points.  Mix arguments that apply to all series (marker/markersize) with arguments unique to each series (colors).  Special arguments `line`, `marker`, and `fill` will automatically figure out what arguments to set (for example, we are setting the `linestyle`, `linewidth`, and `color` arguments with `line`.)  Note that we pass a matrix of colors, and this applies the colors to each series.
+Plot multiple series with different numbers of points.  Mix arguments that apply to all
+series (marker/markersize) with arguments unique to each series (colors).  Special
+arguments `line`, `marker`, and `fill` will automatically figure out what arguments to
+set (for example, we are setting the `linestyle`, `linewidth`, and `color` arguments with
+`line`.)  Note that we pass a matrix of colors, and this applies the colors to each
+series.
 
 ```julia
 ys = Vector[rand(10),rand(20)]
@@ -75,7 +87,7 @@ plot(rand(100) / 3,reg=true,fill=(0,:green))
 
 ![](img/pyplot/pyplot_example_8.png)
 
-### 
+###
 
 and add to it later.
 
@@ -114,7 +126,7 @@ plot(x,y,line=(linetypes,3),lab=map(string,linetypes),ms=15)
 
 
 ```julia
-styles = (filter((s->begin 
+styles = (filter((s->begin
             s in Plots.supported_styles()
         end),[:solid,:dash,:dot,:dashdot,:dashdotdot]))'
 n = length(styles)
@@ -129,7 +141,7 @@ plot(y,line=(5,styles),label=map(string,styles))
 
 
 ```julia
-markers = (filter((m->begin 
+markers = (filter((m->begin
             m in Plots.supported_markers()
         end),Plots._shape_keys))'
 n = length(markers)
@@ -162,27 +174,32 @@ histogram(randn(1000),nbins=20)
 
 ### Subplots
 
-Use the `layout` keyword, and optionally the convenient `@layout` macro to generate arbitrarily complex subplot layouts.
+Use the `layout` keyword, and optionally the convenient `@layout` macro to generate
+arbitrarily complex subplot layouts.
 
 
 ```julia
 l = @layout([a{0.1h};b [c;d e]])
-plot(randn(100,5),layout=l,t=[:line :histogram :scatter :steppre :bar],leg=false,ticks=nothing,border=false)
+plot(randn(100,5),layout=l,
+     t=[:line :histogram :scatter :steppre :bar],leg=false,ticks=nothing,border=false)
 ```
 
 ![](img/pyplot/pyplot_example_16.png)
 
 ### Adding to subplots
 
-Note here the automatic grid layout, as well as the order in which new series are added to the plots.
+Note here the automatic grid layout, as well as the order in which new series are added
+to the plots.
 
 ```julia
-plot(Plots.fakedata(100,10),layout=4,palette=[:grays :blues :heat :lightrainbow],bg_inside=[:orange :pink :darkblue :black])
+plot(Plots.fakedata(100,10),layout=4,
+     palette=[:grays :blues :heat :lightrainbow],
+     bg_inside=[:orange :pink :darkblue :black])
 ```
 
 ![](img/pyplot/pyplot_example_17.png)
 
-### 
+###
 
 
 
@@ -195,7 +212,9 @@ plot!(Plots.fakedata(100,10))
 
 ### Open/High/Low/Close
 
-Create an OHLC chart.  Pass in a list of (open,high,low,close) tuples as your `y` argument.  This uses recipes to first convert the tuples to OHLC objects, and subsequently create a :path series with the appropriate line segments.
+Create an OHLC chart.  Pass in a list of (open,high,low,close) tuples as your `y`
+argument.  This uses recipes to first convert the tuples to OHLC objects, and
+subsequently create a :path series with the appropriate line segments.
 
 ```julia
 n = 20
@@ -203,7 +222,8 @@ hgt = rand(n) + 1
 bot = randn(n)
 openpct = rand(n)
 closepct = rand(n)
-y = OHLC[(openpct[i] * hgt[i] + bot[i],bot[i] + hgt[i],bot[i],closepct[i] * hgt[i] + bot[i]) for i = 1:n]
+y = OHLC[(openpct[i] * hgt[i] + bot[i],bot[i] + hgt[i],bot[i],closepct[i] * hgt[i] +
+          bot[i]) for i = 1:n]
 ohlc(y)
 ```
 
@@ -211,38 +231,51 @@ ohlc(y)
 
 ### Annotations
 
-The `annotations` keyword is used for text annotations in data-coordinates.  Pass in a tuple (x,y,text) or a vector of annotations.  `annotate!(ann)` is shorthand for `plot!(; annotation=ann)`.  Series annotations are used for annotating individual data points.  They require only the annotation... x/y values are computed.  A `PlotText` object can be build with the method `text(string, attr...)`, which wraps font and color attributes.
+The `annotations` keyword is used for text annotations in data-coordinates.  Pass in a
+tuple (x,y,text) or a vector of annotations.  `annotate!(ann)` is shorthand for `plot!(;
+annotation=ann)`.  Series annotations are used for annotating individual data points.
+They require only the annotation... x/y values are computed.  A `PlotText` object can be
+build with the method `text(string, attr...)`, which wraps font and color attributes.
 
 ```julia
 y = rand(10)
 plot(y,annotations=(3,y[3],text("this is #3",:left)),leg=false)
-annotate!([(5,y[5],text("this is #5",16,:red,:center)),(10,y[10],text("this is #10",:right,20,"courier"))])
-scatter!(linspace(2,8,6),rand(6),marker=(50,0.2,:orange),series_annotations=["series","annotations","map","to","series",text("data",:green)])
+annotate!([(5,y[5],text("this is #5",16,:red,:center)),
+          (10,y[10],text("this is #10",:right,20,"courier"))])
+scatter!(linspace(2,8,6),rand(6),marker=(50,0.2,:orange),
+         series_annotations=["series","annotations","map","to","series",
+                             text("data",:green)])
 ```
 
 ![](img/pyplot/pyplot_example_20.png)
 
 ### Custom Markers
 
-A `Plots.Shape` is a light wrapper around vertices of a polygon.  For supported backends, pass arbitrary polygons as the marker shapes.  Note: The center is (0,0) and the size is expected to be rougly the area of the unit circle.
+A `Plots.Shape` is a light wrapper around vertices of a polygon.  For supported backends,
+pass arbitrary polygons as the marker shapes.  Note: The center is (0,0) and the size is
+expected to be rougly the area of the unit circle.
 
 ```julia
-verts = [(-1.0,1.0),(-1.28,0.6),(-0.2,-1.4),(0.2,-1.4),(1.28,0.6),(1.0,1.0),(-1.0,1.0),(-0.2,-0.6),(0.0,-0.2),(-0.4,0.6),(1.28,0.6),(0.2,-1.4),(-0.2,-1.4),(0.6,0.2),(-0.2,0.2),(0.0,-0.2),(0.2,0.2),(-0.2,-0.6)]
+verts =[(-1.0,1.0),(-1.28,0.6),(-0.2,-1.4),(0.2,-1.4),(1.28,0.6),(1.0,1.0),(-1.0,1.0),
+        (-0.2,-0.6),(0.0,-0.2),(-0.4,0.6),(1.28,0.6),(0.2,-1.4),(-0.2,-1.4),(0.6,0.2),
+        (-0.2,0.2),(0.0,-0.2),(0.2,0.2),(-0.2,-0.6)]
 x = 0.1:0.2:0.9
 y = 0.7 * rand(5) + 0.15
-plot(x,y,line=(3,:dash,:lightblue),marker=(Shape(verts),30,RGBA(0,0,0,0.2)),bg=:pink,fg=:darkblue,xlim=(0,1),ylim=(0,1),leg=false)
+plot(x,y,line=(3,:dash,:lightblue),marker=(Shape(verts),30,RGBA(0,0,0,0.2)),bg=:pink,
+     fg=:darkblue,xlim=(0,1),ylim=(0,1),leg=false)
 ```
 
 ![](img/pyplot/pyplot_example_21.png)
 
 ### Contours
 
-Any value for fill works here.  We first build a filled contour from a function, then an unfilled contour from a matrix.
+Any value for fill works here.  We first build a filled contour from a function, then an
+unfilled contour from a matrix.
 
 ```julia
 x = 1:0.5:20
 y = 1:0.5:10
-f(x,y) = begin 
+f(x,y) = begin
         (3x + y ^ 2) * abs(sin(x) + cos(y))
     end
 X = repmat(x',length(y),1)
@@ -288,7 +321,7 @@ plot!(zeros(n),zeros(n),1:n,w=10)
 
 
 ```julia
-group = rand(map((i->begin 
+group = rand(map((i->begin
                     "group $(i)"
                 end),1:4),100)
 plot(rand(100),layout=@layout([a b;c]),group=group,linetype=[:bar :scatter :steppre])
@@ -326,7 +359,9 @@ heatmap(xs,ys,z,aspect_ratio=1)
 
 
 ```julia
-plot(rand(100,6),layout=@layout([a b;c]),title=["A" "B" "C"],title_location=:left,left_margin=[20mm 0mm],bottom_margin=50px,xrotation=60)
+plot(rand(100,6),layout=@layout([a b;c]),
+     title=["A" "B" "C"],title_location=:left,
+     left_margin=[20mm 0mm],bottom_margin=50px,xrotation=60)
 ```
 
 ![](img/pyplot/pyplot_example_29.png)
@@ -337,7 +372,9 @@ The `layout` macro can be used to create an animation with subplots.
 
 ```julia
 l = @layout([[a;b] c])
-p = plot(plot([sin,cos],1,leg=false),scatter([atan,cos],1,leg=false),plot(log,1,xlims=(1,10π),ylims=(0,5),leg=false),layout=l)
+p = plot(plot([sin,cos],1,leg=false),
+         scatter([atan,cos],1,leg=false),
+         plot(log,1,xlims=(1,10π),ylims=(0,5),leg=false),layout=l)
 anim = Animation()
 for x = linspace(1,10π,100)
     plot(push!(p,x,Float64[sin(x),cos(x),atan(x),cos(x),log(x)]))

--- a/docs/src/examples/unicodeplots.md
+++ b/docs/src/examples/unicodeplots.md
@@ -31,7 +31,9 @@ plot(sin,(x->begin  # /Users/tom/.julia/v0.4/Plots/docs/example_generation.jl, l
 
 ### Colors
 
-Access predefined palettes (or build your own with the `colorscheme` method).  Line/marker colors are auto-generated from the plot's palette, unless overridden.  Set the `z` argument to turn on series gradients.
+Access predefined palettes (or build your own with the `colorscheme` method).
+Line/marker colors are auto-generated from the plot's palette, unless overridden.  Set
+the `z` argument to turn on series gradients.
 
 ```julia
 y = rand(100)
@@ -43,10 +45,15 @@ scatter!(y,z=abs(y - 0.5),m=(10,:heat),lab="grad")
 
 ### Global
 
-Change the guides/background/limits/ticks.  Convenience args `xaxis` and `yaxis` allow you to pass a tuple or value which will be mapped to the relevant args automatically.  The `xaxis` below will be replaced with `xlabel` and `xlims` args automatically during the preprocessing step. You can also use shorthand functions: `title!`, `xaxis!`, `yaxis!`, `xlabel!`, `ylabel!`, `xlims!`, `ylims!`, `xticks!`, `yticks!`
+Change the guides/background/limits/ticks.  Convenience args `xaxis` and `yaxis` allow
+you to pass a tuple or value which will be mapped to the relevant args automatically.
+The `xaxis` below will be replaced with `xlabel` and `xlims` args automatically during
+the preprocessing step. You can also use shorthand functions: `title!`, `xaxis!`,
+`yaxis!`, `xlabel!`, `ylabel!`, `xlims!`, `ylims!`, `xticks!`, `yticks!`
 
 ```julia
-plot(rand(20,3),xaxis=("XLABEL",(-5,30),0:2:20,:flip),background_color=RGB(0.2,0.2,0.2),leg=false)
+plot(rand(20,3),xaxis=("XLABEL",(-5,30),0:2:20,:flip),background_color=RGB(0.2,0.2,0.2),
+     leg=false)
 title!("TITLE")
 yaxis!("YLABEL",:log10)
 ```
@@ -67,7 +74,12 @@ plot(Vector[randn(100),randn(100) * 100],axis=[:l :r],ylabel="LEFT",yrightlabel=
 
 ### Arguments
 
-Plot multiple series with different numbers of points.  Mix arguments that apply to all series (marker/markersize) with arguments unique to each series (colors).  Special arguments `line`, `marker`, and `fill` will automatically figure out what arguments to set (for example, we are setting the `linestyle`, `linewidth`, and `color` arguments with `line`.)  Note that we pass a matrix of colors, and this applies the colors to each series.
+Plot multiple series with different numbers of points.  Mix arguments that apply to all
+series (marker/markersize) with arguments unique to each series (colors).  Special
+arguments `line`, `marker`, and `fill` will automatically figure out what arguments to
+set (for example, we are setting the `linestyle`, `linewidth`, and `color` arguments with
+`line`.)  Note that we pass a matrix of colors, and this applies the colors to each
+series.
 
 ```julia
 plot(Vector[rand(10),rand(20)],marker=(:circle,8),line=(:dot,3,[:black :orange]))
@@ -156,23 +168,28 @@ histogram(randn(1000),nbins=50)
 
 ### Subplots
 
-  subplot and subplot! are distinct commands which create many plots and add series to them in a circular fashion.
-  You can define the layout with keyword params... either set the number of plots `n` (and optionally number of rows `nr` or
+  subplot and subplot! are distinct commands which create many plots and add series to
+  them in a circular fashion.
+  You can define the layout with keyword params... either set the number of plots `n`
+  (and optionally number of rows `nr` or
   number of columns `nc`), or you can set the layout directly with `layout`.
 
 
 ```julia
-subplot(randn(100,5),layout=[1,1,3],t=[:line :hist :scatter :step :bar],nbins=10,leg=false)
+subplot(randn(100,5),layout=[1,1,3],
+        t=[:line :hist :scatter :step :bar],nbins=10,leg=false)
 ```
 
 ![](img/unicodeplots/unicodeplots_example_16.png)
 
 ### Adding to subplots
 
-Note here the automatic grid layout, as well as the order in which new series are added to the plots.
+Note here the automatic grid layout, as well as the order in which new series are added
+to the plots.
 
 ```julia
-subplot(fakedata(100,10),n=4,palette=[:grays :blues :heat :lightrainbow],bg=[:orange :pink :darkblue :black])
+subplot(fakedata(100,10),n=4,palette=[:grays :blues :heat :lightrainbow],
+        bg=[:orange :pink :darkblue :black])
 ```
 
 ![](img/unicodeplots/unicodeplots_example_17.png)
@@ -189,11 +206,17 @@ subplot!(fakedata(100,10))
 
 ### Custom Markers
 
-A `Plots.Shape` is a light wrapper around vertices of a polygon.  For supported backends, pass arbitrary polygons as the marker shapes.  Note: The center is (0,0) and the size is expected to be rougly the area of the unit circle.
+A `Plots.Shape` is a light wrapper around vertices of a polygon.  For supported backends,
+pass arbitrary polygons as the marker shapes.  Note: The center is (0,0) and the size is
+expected to be rougly the area of the unit circle.
 
 ```julia
-verts = [(-1.0,1.0),(-1.28,0.6),(-0.2,-1.4),(0.2,-1.4),(1.28,0.6),(1.0,1.0),(-1.0,1.0),(-0.2,-0.6),(0.0,-0.2),(-0.4,0.6),(1.28,0.6),(0.2,-1.4),(-0.2,-1.4),(0.6,0.2),(-0.2,0.2),(0.0,-0.2),(0.2,0.2),(-0.2,-0.6)]
-plot(0.1:0.2:0.9,0.7 * rand(5) + 0.15,l=(3,:dash,:lightblue),m=(Shape(verts),30,RGBA(0,0,0,0.2)),bg=:pink,fg=:darkblue,xlim=(0,1),ylim=(0,1),leg=false)
+verts =[(-1.0,1.0),(-1.28,0.6),(-0.2,-1.4),(0.2,-1.4),(1.28,0.6),(1.0,1.0),(-1.0,1.0),
+        (-0.2,-0.6),(0.0,-0.2),(-0.4,0.6),(1.28,0.6),(0.2,-1.4),(-0.2,-1.4),(0.6,0.2),
+        (-0.2,0.2),(0.0,-0.2),(0.2,0.2),(-0.2,-0.6)]
+plot(0.1:0.2:0.9,0.7 * rand(5) + 0.15,l=(3,:dash,:lightblue),
+     m=(Shape(verts),30,RGBA(0,0,0,0.2)),bg=:pink,fg=:darkblue,
+     xlim=(0,1),ylim=(0,1),leg=false)
 ```
 
 ![](img/unicodeplots/unicodeplots_example_21.png)


### PR DESCRIPTION
In some browsers, the lines with a lot of code in the examples actually
get crossed with the table of contents.

Let me know if there are any other formatting bits and pieces that you
would like to change at the same time.