### PR TITLE
add using Plots.Measures to margins examples

### DIFF
--- a/docs/src/examples/gr.md
+++ b/docs/src/examples/gr.md
@@ -358,8 +358,10 @@ heatmap(xs,ys,z,aspect_ratio=1)
 
 
 ```julia
-plot(rand(100,6), layout=@layout([a b;c]), 
-     title=["A" "B" "C"], title_location=:left, 
+using Plots.Measures
+
+plot(rand(100,6), layout=@layout([a b;c]),
+     title=["A" "B" "C"], title_location=:left,
      left_margin=[20mm 0mm], bottom_margin=50px, xrotation=60)
 ```
 

--- a/docs/src/examples/pgfplots.md
+++ b/docs/src/examples/pgfplots.md
@@ -293,6 +293,8 @@ plot(Θ,r,proj=:polar,m=2)
 
 
 ```julia
+using Plots.Measures
+
 plot(rand(100,6),layout=@layout([a b;c]),
      title=["A" "B" "C"],title_location=:left,
      left_margin=[20mm 0mm],bottom_margin=50px,xrotation=60)

--- a/docs/src/examples/plotlyjs.md
+++ b/docs/src/examples/plotlyjs.md
@@ -344,6 +344,8 @@ heatmap(xs,ys,z,aspect_ratio=1)
 
 
 ```julia
+using Plots.Measures
+
 plot(rand(100,6),layout=@layout([a b;c]),title=["A" "B" "C"],title_location=:left,left_margin=[20mm 0mm],bottom_margin=50px,xrotation=60)
 ```
 

--- a/docs/src/examples/pyplot.md
+++ b/docs/src/examples/pyplot.md
@@ -232,8 +232,8 @@ ohlc(y)
 ### Annotations
 
 The `annotations` keyword is used for text annotations in data-coordinates.  Pass in a
-tuple `(x, y, text)` or a vector of annotations.  `annotate!(ann)` is shorthand for 
-`plot!(; annotations=ann)`.  Series annotations are used for annotating individual data 
+tuple `(x, y, text)` or a vector of annotations.  `annotate!(ann)` is shorthand for
+`plot!(; annotations=ann)`.  Series annotations are used for annotating individual data
 points.
 They require only the annotation... x/y values are computed.  A `PlotText` object can be
 build with the method `text(string, attr...)`, which wraps font and color attributes.
@@ -360,6 +360,8 @@ heatmap(xs,ys,z,aspect_ratio=1)
 
 
 ```julia
+using Plots.Measures
+
 plot(rand(100,6),layout=@layout([a b;c]),
      title=["A" "B" "C"],title_location=:left,
      left_margin=[20mm 0mm],bottom_margin=50px,xrotation=60)


### PR DESCRIPTION
Examples for shifting margins within layouts need `using Plots.Measures` to work. I've added that to the example folder, let me know if there are any other places this might be required.