### PR TITLE
typo (change "<" to ">")

### DIFF
--- a/docs/src/input_data.md
+++ b/docs/src/input_data.md
@@ -46,7 +46,7 @@ This example plots the four series with different labels, marker shapes, and mar
 
 ## Unconnected Data within same groups
 
-As shown in the examples, you can plot a single polygon by using a single call to `plot` using the `:path` line type. You can use several calls to `plot` to draw several polygons
+As shown in the examples, you can plot a single polygon by using a single call to `plot` using the `:path` line type. You can use several calls to `plot` to draw several polygons.
 
 Now, let's say you're plotting `n` polygons grouped into `g` groups, with `n` > `g`. While you can use `plot` to draw separate polygons with each call, you cannot group two separate plots back into a single group. You'll end up with `n` groups in the legend, rather than `g` groups.
 

--- a/docs/src/input_data.md
+++ b/docs/src/input_data.md
@@ -48,7 +48,7 @@ This example plots the four series with different labels, marker shapes, and mar
 
 As shown in the examples, you can plot a single polygon by using a single call to `plot` using the `:path` line type. You can use several calls to `plot` to draw several polygons
 
-Now, let's say you're plotting `n` polygons grouped into `g` groups, with `n` < `g`. While you can use `plot` to draw separate polygons with each call, you cannot group two separate plots back into a single group. You'll end up with `n` groups in the legend, rather than `g` groups.
+Now, let's say you're plotting `n` polygons grouped into `g` groups, with `n` > `g`. While you can use `plot` to draw separate polygons with each call, you cannot group two separate plots back into a single group. You'll end up with `n` groups in the legend, rather than `g` groups.
 
 To adress this, you can use `NaN` as a path separator. A call to `plot` would then draw one path with disjoints The following code draws `n=4` rectangles in `g=2` groups.
 


### PR DESCRIPTION
I think one usually has less groups than polygons.