### PR TITLE
Switch to Project.toml, cap Documenter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+Manifest.toml
 docs/build/
 docs/site/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ script:
   # - Run docs/make.jl to build the docs
   # - Uses a bash heredoc to pipe the "script" into the standard input (<<EOF .. EOF)
   #
-  - JULIA_LOAD_PATH="$PWD/src/:@:@stdlib" julia --project <<EOF
+  - |
+    JULIA_LOAD_PATH="$PWD/src/:@:@stdlib" julia --project <<EOF
         using Pkg
         Pkg.instantiate()
         include("docs/make.jl")

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   # - Uses a bash heredoc to pipe the "script" into the standard input (<<EOF .. EOF)
   #
   - |
-    JULIA_LOAD_PATH="$PWD/src/:@:@stdlib" julia --project <<EOF
+    JULIA_LOAD_PATH="$PWD/src/:@:@stdlib" julia --project --color=yes <<EOF
         using Pkg
         Pkg.instantiate()
         include("docs/make.jl")

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,15 @@ notifications:
   email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'import Pkg; Pkg.add(Pkg.PackageSpec(path = pwd())); Pkg.add("Documenter"); Pkg.add("Plots"); include("docs/make.jl")'
+  # The command to build the docs does the following:
+  #
+  # - Modify the LOAD_PATH so that we could load the code in src/PlotDocs.jl
+  # - Instantiate the dependencies in the Project.toml
+  # - Run docs/make.jl to build the docs
+  # - Uses a bash heredoc to pipe the "script" into the standard input (<<EOF .. EOF)
+  #
+  - JULIA_LOAD_PATH="$PWD/src/:@:@stdlib" julia --project <<EOF
+        using Pkg
+        Pkg.instantiate()
+        include("docs/make.jl")
+    EOF

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+
+[compat]
+Documenter = "~0.19"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.7
-Plots
-DataFrames


### PR DESCRIPTION
Use a Project.toml, instead of a mix of a `REQUIRE` file + `Pkg.add` commands to define the environment for the doc build. Also, cap Documenter to 0.19 due to [upcoming breaking changes](https://discourse.julialang.org/t/psa-documenter-jl-breaking-changes-version-capping/16431).

I am basically just playing around here a bit, trying to figure out what would be a good pattern to use for repositories like this that are not really packages. Doing it this way, I don't think you can have PlotDocs as a package in an environment, so I am guessing it might break people's workflows?