### PR TITLE
Use -e option instead of heredoc in Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ script:
   # - Modify the LOAD_PATH so that we could load the code in src/PlotDocs.jl
   # - Instantiate the dependencies in the Project.toml
   # - Run docs/make.jl to build the docs
-  # - Uses a bash heredoc to pipe the "script" into the standard input (<<EOF .. EOF)
+  # - Use a YAML block scalar (|) for a proper multiline command
   #
   - |
-    JULIA_LOAD_PATH="$PWD/src/:@:@stdlib" julia --project --color=yes <<EOF
+    JULIA_LOAD_PATH="$PWD/src/:@:@stdlib" julia --project --color=yes -e'
         using Pkg
         Pkg.instantiate()
         include("docs/make.jl")
-    EOF
+    '


### PR DESCRIPTION
This follows up on #111. It makes sure that the Travis job actually fails when there is an error somewhere in the script.

The heredoc does not work because Julia does not set the return code appropriately when the scripts are passed via stdin (ref: JuliaLang/julia#30039).