### PR TITLE
Add decision boundary example to index page

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -104,6 +104,35 @@ end
 
 ![waves](https://raw.githubusercontent.com/JuliaPlots/PlotReferenceImages.jl/master/PlotDocs/index/waves.gif)
 
+Decision boundary
+
+```julia
+P = 40;  R = 50;  N = P*R;  r = 0:0.004:1
+points = rand(ComplexF64, P, R)
+grad = cgrad(cgrad(:lighttest).colors[[1:end; 1]])
+
+mp4(@animate(for t = 0:0.03:13
+    # create a simple classifier to return the region for any point (x, y)
+    midpoints = sum(points; dims=1)[:] / P
+    classify(x, y) = argmin(abs.(x + y*im .- midpoints))
+
+    # draw decision boundary and points
+    contour(r, r, classify, c=grad, fill=true, nlev=R, leg=:none)
+    scatter!(reim(points)..., c=cvec(grad, R)', lims=(0,1))
+
+    # update position of points
+    target(d) = 0.65*cis(4*sin(t/2+d)+d) + 0.5 + 0.5im
+    points[:] .+= 0.01*(target.(0:2π/(N-1):2π) .- points[:])
+end), "decision.mp4", fps = 30)
+```
+
+```@raw html
+<video width="600" height="400" controls loop poster="https://raw.githubusercontent.com/JuliaPlots/PlotReferenceImages.jl/master/PlotDocs/index/decision-poster.png">
+  <source src="https://raw.githubusercontent.com/JuliaPlots/PlotReferenceImages.jl/master/PlotDocs/index/decision.mp4" type="video/mp4">
+  Your browser does not support the video tag.
+</video>
+```
+
 Iris Dataset
 
 ```julia

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -109,7 +109,6 @@ Decision boundary
 ```julia
 P = 40;  R = 50;  N = P*R;  r = 0:0.004:1
 points = rand(ComplexF64, P, R)
-grad = cgrad(cgrad(:lighttest).colors[[1:end; 1]])
 
 mp4(@animate(for t = 0:0.03:13
     # create a simple classifier to return the region for any point (x, y)
@@ -117,8 +116,8 @@ mp4(@animate(for t = 0:0.03:13
     classify(x, y) = argmin(abs.(x + y*im .- midpoints))
 
     # draw decision boundary and points
-    contour(r, r, classify, c=grad, fill=true, nlev=R, leg=:none)
-    scatter!(reim(points)..., c=cvec(grad, R)', lims=(0,1))
+    contour(r, r, classify, c=:cyclic2, fill=true, nlev=R, leg=:none)
+    scatter!(reim(points)..., c=cvec(:cyclic2, R)', lims=(0,1))
 
     # update position of points
     target(d) = 0.65*cis(4*sin(t/2+d)+d) + 0.5 + 0.5im

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -113,7 +113,7 @@ grad = cgrad(cgrad(:lighttest).colors[[1:end; 1]])
 
 mp4(@animate(for t = 0:0.03:13
     # create a simple classifier to return the region for any point (x, y)
-    midpoints = sum(points; dims=1)[:] / P
+    midpoints = vec(sum(points; dims=1)) / P
     classify(x, y) = argmin(abs.(x + y*im .- midpoints))
 
     # draw decision boundary and points


### PR DESCRIPTION
As suggested in a [recent Discourse post](https://discourse.julialang.org/t/plotting-decision-boundary-regions-for-classifier/21397/7). Updated and optimized version.

I chose MP4 over animated GIF since the GIF is around 30 MB large (and perhaps it's interesting for people to see how easy it is to create MP4 videos).

The corresponding [PR in PlotReferenceImages.jl](https://github.com/JuliaPlots/PlotReferenceImages.jl/pull/37) should be merged before this one.

Note: I've tested the embedded video locally with `Documenter` and it worked fine, but couldn't figure out how to test it with MkDocs.