### PR TITLE
add information about tick labels

### DIFF
--- a/docs/src/attributes.md
+++ b/docs/src/attributes.md
@@ -70,7 +70,7 @@ plot(y, xlabel = "my label",
 
 Note that `yaxis` and `zaxis` work similarly, and `axis` will apply to all.
 
-Passing a tuple to `xticks` (and similarlly to `yticks` and `zticks`) changes
+Passing a tuple to `xticks` (and similarly to `yticks` and `zticks`) changes
 the position of the ticks and the labels:
 
 ```julia

--- a/docs/src/attributes.md
+++ b/docs/src/attributes.md
@@ -70,6 +70,14 @@ plot(y, xlabel = "my label",
 
 Note that `yaxis` and `zaxis` work similarly, and `axis` will apply to all.
 
+Passing a tuple to `xticks` (and similarlly to `yticks` and `zticks`) changes
+the position of the ticks and the labels:
+
+```julia
+plot!(xticks = ([0:π:3*π;], ["0", "\\pi", "2\\pi"]))
+yticks!([-1:1:1;], ["min", "zero", "max"])
+```
+
 ##### line
 
 Set attributes corresponding to a series line.  Aliases: `l`.  The following are equivalent:


### PR DESCRIPTION
Example code:

```
using Plots

x = [0:0.1:3*π;]
y = [sin(i) for i in x]

plot(x, y)
plot!(xticks = ([0:π:3*π;], ["0", "\\pi", "2\\pi"]))
yticks!([-1:1:1;], ["min", "zero", "max"])

savefig("pis.png")
```

Output:
![pis](https://user-images.githubusercontent.com/13461702/55514764-54f85500-563f-11e9-883f-b700cdfd3c87.png)
