### PR TITLE
Add a reference sheets section

### DIFF
--- a/docs/src/learning.md
+++ b/docs/src/learning.md
@@ -12,6 +12,10 @@
 - [ExamplePlots](https://github.com/JuliaPlots/ExamplePlots.jl)
 - [Some notebooks](https://github.com/tbreloff/notebooks)
 
+# Reference sheets
+
+- [A one-page Plots.jl cheatsheet](https://github.com/sswatson/cheatsheets/blob/master/plotsjl-cheatsheet.pdf)
+
 # Video tutorials
 
 ### Plots with Plots - JuliaCon 2016


### PR DESCRIPTION
Add a section for reference sheets, with a link to a Plots.jl reference sheet on GitHub. Previously discussed on [this Plots.jl issue](https://github.com/JuliaPlots/Plots.jl/issues/1961). 