### PR TITLE
generate marginalhist image

### DIFF
--- a/src/doc_image_constants.jl
+++ b/src/doc_image_constants.jl
@@ -277,6 +277,7 @@ const DOC_IMAGES = OrderedDict(
         #Pkg.add("RDatasets")
         using RDatasets
         iris = dataset("datasets", "iris")
+        @df iris marginalhist(:PetalLength, :PetalWidth)
     end],
 
 


### PR DESCRIPTION
Fix wrong image in "Using Plot Recipes" section of the tutorial.