### PR TITLE
Add documentation for GraphRecipes

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -27,7 +27,14 @@ pages:
 
   - Learning: learning.md
   - Contributing: contributing.md
-  - Ecosystem: ecosystem.md
+
+  - Ecosystem:
+      - Overview: ecosystem.md
+      - GraphRecipes:
+          - Introduction: graphrecipes/introduction.md
+          - Examples: graphrecipes/examples.md
+          - Attributes: graphrecipes/attributes.md
+
   - Advanced Topics:
       - Internals: pipeline.md
 

--- a/docs/src/ecosystem.md
+++ b/docs/src/ecosystem.md
@@ -41,28 +41,6 @@ Much of this functionality once existed in core Plots, but has been moved out to
 ![](https://cloud.githubusercontent.com/assets/933338/16718720/729b6fea-46f0-11e6-9bff-fdf2541ce305.png)
 
 
-
-
-## [PlotRecipes](https://github.com/JuliaPlots/PlotRecipes.jl)
-
-A catch-all for functionality and recipes which don't have a home elsewhere.  Graphs (networks of nodes and edges), maps/shapes, finance, and more.
-
-
-![graph3d](https://cloud.githubusercontent.com/assets/933338/16094180/0dd2edf0-330d-11e6-8596-d12b0b8d5393.png)
-
-
-![graph_layout](https://cloud.githubusercontent.com/assets/933338/16698919/ee1f9e76-451e-11e6-8936-881551f120dd.gif)
-
-
-![arcs](https://cloud.githubusercontent.com/assets/2822757/16072526/aba39c2e-32b7-11e6-947c-6faab1d13cc7.png)
-
-
-![map](https://cloud.githubusercontent.com/assets/933338/16770876/83dea362-481c-11e6-9943-bb77148be5b8.png)
-
-
-![portcomp](https://cloud.githubusercontent.com/assets/933338/17529235/96a48040-5e40-11e6-8698-7d371f36fd22.png)
-
-
 ---
 
 # Community packages

--- a/docs/src/graphrecipes/attributes.md
+++ b/docs/src/graphrecipes/attributes.md
@@ -1,0 +1,104 @@
+# Graph Attributes
+Where possible, GraphRecipes will adopt attributes from Plots.jl to format visualizations.
+For example, the `linewidth` attribute from Plots.jl has the same effect in GraphRecipes.
+In order to give the user control over the layout of the graph visualization, GraphRecipes
+provides a number of keyword arguments (attributes). Here we describe those attributes
+alongside their default values.
+
+### `dim = 2`
+The number of dimensions in the visualization.
+
+### `T = Float64`
+The data type for the coordinates of the graph nodes.
+### `curves = true`
+Whether or not edges are curved. If `curves == true`, then the edge going from node $s$ to
+node $d$ will be defined by a cubic spline passing through three points: (i) node $s$,
+(ii) a point `p` that is distance `curvature_scalar` from the average of node $s$ and node
+$d$ and (iii) node $d$.
+### `curvature_scalar = 0.05`
+A scalar that defines how much edges curve, see `curves` for more explanation.
+### `root = :top`
+For displaying trees, choose from `:top`, `:bottom`, `:left`, `:right`. If you choose
+`:top`, then the tree will be plotted from the top down.
+
+### `node_weights = nothing`
+The weight of the nodes given by a list of numbers. If `node_weights != nothing`, then the
+size of the nodes will be scaled by the `node_weights` vector.
+### `names = []`
+Names of the nodes given by a list of objects that can be parsed into strings. If the list
+is smaller than the number of nodes, then GraphRecipes will cycle around the list.
+### `fontsize = 7`
+Font size for the node labels and the edge labels.
+### `nodeshape = :hexagon`
+Shape of the nodes, choose from `:hexagon`, `circle`, `ellipse`, `rect` or `rectangle`.
+### `nodesize = 0.1`
+The size of nodes in the plot coordinates. Note that if `names` is not empty, then nodes
+will be scaled to fit the labels inside them.
+### `nodecolor = 1`
+The color of the nodes. If `nodecolor` is an integer, then it will be taken from the
+current color pallette. Otherwise, the user can pass any color that would be recognised by
+the Plots `color` attribute.
+### `x = nothing` `y = nothing` `z = nothing`
+The coordinates of the nodes.
+### `method = :stress`
+The method that GraphRecipes uses to produce an optimal layout, choose from `:spectral`,
+`:sfdp`, `:circular`, `:shell`, `:stress`, `:spring`, `:tree`, `:buchheim`, `:arcdiagram`
+or `:chorddiagram`. See [NetworkLayout](https://github.com/JuliaGraphs/NetworkLayout.jl)
+for further details.
+### `func = get(_graph_funcs, method, by_axis_local_stress_graph)`
+A layout algorithm that can be passed in by the user.
+### `shorten = 0.0`
+An amount to shorten edges by.
+### `axis_buffer = 0.2`
+Increase the `xlims` and `ylims`/`zlims` of the plot. Can be useful if part of the graph
+sits outside of the default view.
+### `layout_kw = Dict{Symbol,Any}()`
+A list of keywords to be passed to the layout algorithm, see
+[NetworkLayout](https://github.com/JuliaGraphs/NetworkLayout.jl) for a list of keyword
+arguments for each algorithm.
+### `edgewidth = (s,d,w)->1`
+The width of the edge going from $s$ to node $d$ with weight $w$.
+### `edgelabel = nothing`
+A dictionary of `(s, d) => label`, where `s` is an integer for the source node, `d` is an
+integer for the destiny node and `label` is the desired label for the given edge.
+Alternatively the user can pass a vector or a matrix describing the edge labels. If you
+use a vector or matrix, then either `missing`, `false`, `nothing`, `NaN` or `""` values
+will not be displayed.
+
+In the case of multigraphs, triples can be used to define edges.
+### `edgelabel_offset = 0.0`
+The distance between edge labels and edges.
+### `self_edge_size = 0.1`
+The size of self edges.
+### `edge_label_box = true`
+A box around edge labels that avoids intersections between edge labels and the edges that
+they are labeling.
+
+## Aliases
+Certain keyword arguments have aliases, so GraphRecipes "does what you mean, not
+what you say". Here is a list of keyword arguments with their aliases:
+```
+:curvature_scalar => [:curvaturescalar,:curvature],
+:node_weights => [:nodeweights],
+:nodeshape => [:node_shape],
+:nodesize => [:node_size],
+:nodecolor => [:marker_color],
+:shorten => [:shorten_edge],
+:axis_buffer => [:axisbuffer],
+:edgewidth => [:edge_width,:ew],
+:edgelabel => [:edge_label,:el],
+:edgelabel_offset => [:edgelabeloffset,:elo],
+:self_edge_size => [:selfedgesize,:ses],
+:edge_label_box => [:edgelabelbox,:edgelabel_box,:elb]
+```
+So for example, `nodeshape=:rect` and `node_shape=:rect` are equivalent. To see the
+available aliases, type `GraphRecipes.graph_aliases`. If you are unhappy with the provided
+aliases, then you can add your own:
+```julia
+using GraphRecipes, Plots
+
+push!(GraphRecipes.graph_aliases[:nodecolor],:nc)
+
+# These two calls produce the same plot, modulo some randomness in the layout.
+plot(graphplot([0 1; 0 0], nodecolor=:red), graphplot([0 1; 0 0], nc=:red))
+```

--- a/docs/src/graphrecipes/examples.md
+++ b/docs/src/graphrecipes/examples.md
@@ -1,0 +1,188 @@
+### Undirected graph
+Plot an undirected graph with labeled nodes and individual node sizes/colors.
+```julia
+using GraphRecipes
+using Plots
+
+const n = 15
+const A = Float64[ rand() < 0.5 ? 0 : rand() for i=1:n, j=1:n]
+for i=1:n
+    A[i, 1:i-1] = A[1:i-1, i]
+    A[i, i] = 0
+end
+
+graphplot(A,
+          markersize = 0.2,
+          node_weights = 1:n,
+          markercolor = range(colorant"yellow", stop=colorant"red", length=n),
+          names = 1:n,
+          fontsize = 10,
+          linecolor = :darkgrey
+          )
+```
+
+![](https://user-images.githubusercontent.com/8610352/74630965-9abefd00-51c0-11ea-921d-f0dc3e8f8651.png)
+
+Now plot the graph in three dimensions.
+```julia
+graphplot(A,
+           node_weights = 1:n,
+           markercolor = :darkgray,
+           dim = 3,
+           markersize = 5,
+           linecolor = :darkgrey,
+           linealpha = 0.5
+       )
+
+```
+
+![](https://user-images.githubusercontent.com/8610352/74630887-7105d600-51c0-11ea-9d1c-3c3c65d728e7.png)
+
+### LightGraphs.jl
+You can visualize a `LightGraphs.AbstractGraph` by passing it to `graphplot`.
+```julia
+using GraphRecipes, Plots
+using LightGraphs
+
+g = wheel_graph(10)
+graphplot(g, curves=false)
+```
+
+![](https://user-images.githubusercontent.com/8610352/74631053-de196b80-51c0-11ea-8cba-ddbdc2c6312f.png)
+#### Directed Graphs
+I you pass `graphplot` a `LightGraphs.DiGraph` or an asymmetric adjacency matrix, then `graphplot` will use arrows to indicate the direction of the edges. Note that using the `arrow` attribute with the `pyplot` backend will allow you to control the aesthetics of the arrows.
+```julia
+using GraphRecipes, Plots
+g = [0 1 1;
+     0 0 1;
+     0 1 0]
+
+graphplot(g, names=1:3, curvature_scalar=0.1)
+```
+
+![](https://user-images.githubusercontent.com/8610352/74631107-04d7a200-51c1-11ea-87c1-be9cbf1b02eb.png)
+#### Edge Labels
+Edge labels can be passed via the `edgelabel` keyword argument. You can pass edge labels
+as a dictionary of `(si::Int, di::Int) => label`, where `si`, `di` are the indices of the source and destiny nodes for the edge being labeled. Alternatively, you can pass a matrix or a vector of labels. `graphplot` will try to convert any label you pass it into a string unless you pass one of `missing`, `NaN`, `nothing`, `false` or `""`, in which case, `graphplot` will skip the label.
+
+```julia
+using GraphRecipes, Plots
+using LightGraphs
+
+n = 8
+g = wheel_digraph(n)
+edgelabel_dict = Dict()
+edgelabel_mat = Array{String}(undef, n, n)
+for i in 1:n
+    for j in 1:n
+        edgelabel_mat[i, j] = edgelabel_dict[(i, j)] = string("edge ", i, " to ", j)
+    end
+end
+edgelabel_vec = edgelabel_mat[:]
+
+graphplot(g, names=1:n, edgelabel=edgelabel_dict, curves=false, nodeshape=:rect)  # Or edgelabel=edgelabel_mat, or edgelabel=edgelabel_vec.
+```
+
+![](https://user-images.githubusercontent.com/8610352/74631218-4b2d0100-51c1-11ea-8cd0-ecb7daac4ebb.png)
+#### Self edges
+```julia
+using LightGraphs, Plots, GraphRecipes
+
+g = [1 1 1;
+     0 0 1;
+     0 0 1]
+
+graphplot(DiGraph(g), self_edge_size=0.2)
+```
+![](https://user-images.githubusercontent.com/8610352/74634698-44a28780-51c9-11ea-849a-bd2d675bea73.png)
+#### Multigraphs
+```julia
+graphplot([[1,1,2,2],[1,1,1],[1]], names="node_".*string.(1:3), nodeshape=:circle, self_edge_size=0.25)
+```
+![](https://user-images.githubusercontent.com/8610352/74631260-67c93900-51c1-11ea-8f78-057be37388be.png)
+#### Arc and chord diagrams
+
+```julia
+using LinearAlgebra
+using SparseArrays
+using GraphRecipes
+using Plots
+
+adjmat = Symmetric(sparse(rand(0:1,8,8)))
+
+plot(
+    graphplot(adjmat,
+              method=:chorddiagram,
+              names=[text(string(i), 8) for i in 1:8],
+              linecolor=:black,
+              fillcolor=:lightgray),
+
+    graphplot(adjmat,
+              method=:arcdiagram,
+              markersize=0.5,
+              linecolor=:black,
+              markercolor=:black)
+    )
+
+```
+![](https://user-images.githubusercontent.com/8610352/74631298-82031700-51c1-11ea-8149-c304ac667cea.png)
+
+
+#### Julia code -- AST
+
+```julia
+using GraphRecipes
+using Plots
+default(size=(1000, 1000))
+
+code = :(
+function mysum(list)
+    out = 0
+    for value in list
+        out += value
+    end
+    out
+end
+)
+
+plot(code, fontsize=12, shorten=0.01, axis_buffer=0.15, nodeshape=:rect)
+
+```
+
+![](https://user-images.githubusercontent.com/8610352/74631335-96471400-51c1-11ea-9721-c1167d565417.png)
+
+#### Julia Type Trees
+
+```julia
+using GraphRecipes
+using Plots
+default(size=(1000, 1000))
+
+plot(AbstractFloat, method=:tree, fontsize=10, nodeshape=:ellipse)
+
+```
+![](https://user-images.githubusercontent.com/8610352/74631370-ae1e9800-51c1-11ea-9871-99a618e7ba34.png)
+
+
+#### `AbstractTrees` Trees
+
+```julia
+using AbstractTrees
+
+AbstractTrees.children(d::Dict) = [p for p in d]
+AbstractTrees.children(p::Pair) = AbstractTrees.children(p[2])
+function AbstractTrees.printnode(io::IO, p::Pair)
+    str = isempty(AbstractTrees.children(p[2])) ? string(p[1], ": ", p[2]) : string(p[1], ": ")
+    print(io, str)
+end
+
+d = Dict(:a => 2,:d => Dict(:b => 4,:c => "Hello"),:e => 5.0)
+
+using GraphRecipes
+using Plots
+default(size=(1000, 1000))
+
+plot(TreePlot(d), method=:tree, fontsize=10, nodeshape=:ellipse)
+
+```
+![](https://user-images.githubusercontent.com/8610352/74631477-f1790680-51c1-11ea-878b-b4c92cbf6f85.png)

--- a/docs/src/graphrecipes/introduction.md
+++ b/docs/src/graphrecipes/introduction.md
@@ -1,0 +1,22 @@
+# GraphRecipes
+[GraphRecipes](https://github.com/JuliaPlots/GraphRecipes.jl) is a collection of recipes for visualizing graphs. Users specify a graph through an adjacency matrix, an adjacency list, or an `AbstractGraph` via [LightGraphs](https://github.com/JuliaGraphs/LightGraphs.jl). GraphRecipes will then use a layout algorithm to produce a visualization of the graph that the user passed.
+
+## Installation
+GraphRecipes can be installed with the package manager:
+```julia
+] add GraphRecipes
+```
+
+## Usage
+The main user interface is through the fuction `graphplot`:
+```julia
+using GraphRecipes, Plots
+
+g = [0  1  1;
+     1  0  1;
+     1  1  0]
+graphplot(g)
+```
+![](https://user-images.githubusercontent.com/8610352/74631816-c9d66e00-51c2-11ea-8f4c-dae28a5a4146.png)
+
+See [Examples](examples.md) for example usages and [Attributes](attributes.md) for an explanation of keyword arguments to the `graphplot` function.


### PR DESCRIPTION
I finally kicked the procrastination monster and did this.

## Summary
* Slight restructure of the ecosystem bit, GraphRecipes has its own page separate from all of the other ecosystem examples
* PlotRecipes entry in the ecosystem is deleted, which makes sense, since it is now defunct
* Added examples from GraphRecipes readme as well as an explanation of all of the keyword arguments

Part of https://github.com/JuliaPlots/GraphRecipes.jl/issues/59
