### PR TITLE
Added Introduction to Attributes

### DIFF
--- a/docs/src/attributes.md
+++ b/docs/src/attributes.md
@@ -1,11 +1,15 @@
 
 # [Attributes](@id attributes)
 
+```@setup attr
+using Plots
+```
+
 ### Introduction to Attributes
 
 In Plots, input data is passed positionally (for example, the `y` in `plot(y)`), and attributes are passed as keywords (for example, `plot(y, color = :blue)`). 
-
-Most of the information on this page is available from your Julia REPL. After one executes, `using Plots` in the REPL, one can use the function `plotattr()` to print a list of all attributes for either series, plots, subplots, or axes.
+Most of the information on this page is available from your Julia REPL.
+After one executes, `using Plots` in the REPL, one can use the function `plotattr()` to print a list of all attributes for either series, plots, subplots, or axes.
 
 ```julia
 # Valid Operations
@@ -17,15 +21,9 @@ plotattr(:Axis)
 
 Once you acquire the list of attributes, you can either use the aliases of a specific attribute or investigate a specific attribut to print that attribute's aliases and its description.
 
-```sh
+```@repl attr
 # Specific Attribute Example
-julia> plotattr("size")
-
-size {NTuple{2,Int}}
-windowsize, wsize
-
-(width_px, height_px) of the whole Plot
-Plot attribute,  default: (600, 400)
+plotattr("size")
 ```
 
 !!! note

--- a/docs/src/attributes.md
+++ b/docs/src/attributes.md
@@ -3,7 +3,9 @@
 
 ### Introduction to Attributes
 
-In Plots, input data is passed positionally (for example, the `y` in `plot(y)`), and attributes are passed as keywords (for example, `plot(y, color = :blue)`). Most of the information on this page is available from your Julia REPL. After one executes, `using Plots` in their REPL, one can use the function `plotattr()` to print a list of all attributes for either series, plots, subplots, or axes.
+In Plots, input data is passed positionally (for example, the `y` in `plot(y)`), and attributes are passed as keywords (for example, `plot(y, color = :blue)`). 
+
+Most of the information on this page is available from your Julia REPL. After one executes, `using Plots` in the REPL, one can use the function `plotattr()` to print a list of all attributes for either series, plots, subplots, or axes.
 
 ```julia
 # Valid Operations

--- a/docs/src/attributes.md
+++ b/docs/src/attributes.md
@@ -1,33 +1,10 @@
 
 # [Attributes](@id attributes)
 
-### Introduction to Attributes
+In Plots, input data is passed positionally (for example, the `y` in `plot(y)`), and attributes are passed as keywords (for example, `plot(y, color = :blue)`).
 
-In Plots, input data is passed positionally (for example, the `y` in `plot(y)`), and attributes are passed as keywords (for example, `plot(y, color = :blue)`). Most of the information on this page is available from your Julia REPL. After one executes, `using Plots` in their REPL, one can use the function `plotattr()` to print a list of all attributes for either series, plots, subplots, or axes.
-
-```julia
-# Valid Operations
-plotattr(:Plot)
-plotattr(:Series)
-plotattr(:Subplot)
-plotattr(:Axis)
-```
-
-Once you acquire the list of attributes, you can either use the aliases of a specific attribute or investigate a specific attribut to print that attribute's aliases and its description.
-
-```sh
-# Specific Attribute Example
-julia> plotattr("size")
-
-size {NTuple{2,Int}}
-windowsize, wsize
-
-(width_px, height_px) of the whole Plot
-Plot attribute,  default: (600, 400)
-```
-
-!!! note
-    Do not forget to enclose the attribute you are attempting to use with double quotes! 
+!!! tip
+    Most of the information on this page is available from your Julia session with the function `plotattr`, e.g. `plotattr(:Series)` to print a list of all series attributes, or `plotattr("ms")` to print the aliases and descriptions of `markersize`.
 
 ---
 

--- a/docs/src/attributes.md
+++ b/docs/src/attributes.md
@@ -1,10 +1,33 @@
 
 # [Attributes](@id attributes)
 
-In Plots, input data is passed positionally (for example, the `y` in `plot(y)`), and attributes are passed as keywords (for example, `plot(y, color = :blue)`).
+### Introduction to Attributes
 
-!!! tip
-    Most of the information on this page is available from your Julia session with the function `plotattr`, e.g. `plotattr(:Series)` to print a list of all series attributes, or `plotattr("ms")` to print the aliases and descriptions of `markersize`.
+In Plots, input data is passed positionally (for example, the `y` in `plot(y)`), and attributes are passed as keywords (for example, `plot(y, color = :blue)`). Most of the information on this page is available from your Julia REPL. After one executes, `using Plots` in their REPL, one can use the function `plotattr()` to print a list of all attributes for either series, plots, subplots, or axes.
+
+```julia
+# Valid Operations
+plotattr(:Plot)
+plotattr(:Series)
+plotattr(:Subplot)
+plotattr(:Axis)
+```
+
+Once you acquire the list of attributes, you can either use the aliases of a specific attribute or investigate a specific attribut to print that attribute's aliases and its description.
+
+```sh
+# Specific Attribute Example
+julia> plotattr("size")
+
+size {NTuple{2,Int}}
+windowsize, wsize
+
+(width_px, height_px) of the whole Plot
+Plot attribute,  default: (600, 400)
+```
+
+!!! note
+    Do not forget to enclose the attribute you are attempting to use with double quotes! 
 
 ---
 
@@ -50,7 +73,7 @@ Passing a tuple to `xticks` (and similarly to `yticks` and `zticks`) changes
 the position of the ticks and the labels:
 
 ```julia
-plot!(xticks = ([0:π:3*π;], ["0", "\\pi", "2\\pi"]))
+plot!(xticks = ([0:π:3*π;], ["0", "\pi", "2\pi"]))
 yticks!([-1:1:1;], ["min", "zero", "max"])
 ```
 
@@ -103,3 +126,4 @@ scatter(y,
     markerstrokestyle = :dot
 )
 ```
+

--- a/docs/src/attributes.md
+++ b/docs/src/attributes.md
@@ -1,10 +1,33 @@
 
 # [Attributes](@id attributes)
 
-In Plots, input data is passed positionally (for example, the `y` in `plot(y)`), and attributes are passed as keywords (for example, `plot(y, color = :blue)`).
+### Introduction to Attributes
 
-!!! tip
-    Most of the information on this page is available from your Julia session with the function `plotattr`, e.g. `plotattr(:Series)` to print a list of all series attributes, or `plotattr("ms")` to print the aliases and descriptions of `markersize`.
+In Plots, input data is passed positionally (for example, the `y` in `plot(y)`), and attributes are passed as keywords (for example, `plot(y, color = :blue)`). Most of the information on this page is available from your Julia REPL. After one executes, `using Plots` in their REPL, one can use the function `plotattr()` to print a list of all attributes for either series, plots, subplots, or axes.
+
+```julia
+# Valid Operations
+plotattr(:Plot)
+plotattr(:Series)
+plotattr(:Subplot)
+plotattr(:Axis)
+```
+
+Once you acquire the list of attributes, you can either use the aliases of a specific attribute or investigate a specific attribut to print that attribute's aliases and its description.
+
+```sh
+# Specific Attribute Example
+julia> plotattr("size")
+
+size {NTuple{2,Int}}
+windowsize, wsize
+
+(width_px, height_px) of the whole Plot
+Plot attribute,  default: (600, 400)
+```
+
+!!! note
+    Do not forget to enclose the attribute you are attempting to use with double quotes! 
 
 ---
 

--- a/docs/src/attributes.md
+++ b/docs/src/attributes.md
@@ -1,33 +1,10 @@
 
 # [Attributes](@id attributes)
 
-### Introduction to Attributes
+In Plots, input data is passed positionally (for example, the `y` in `plot(y)`), and attributes are passed as keywords (for example, `plot(y, color = :blue)`).
 
-In Plots, input data is passed positionally (for example, the `y` in `plot(y)`), and attributes are passed as keywords (for example, `plot(y, color = :blue)`). Most of the information on this page is available from your Julia REPL. After one executes, `using Plots` in their REPL, one can use the function `plotattr()` to print a list of all attributes for either series, plots, subplots, or axes.
-
-```julia
-# Valid Operations
-plotattr(:Plot)
-plotattr(:Series)
-plotattr(:Subplot)
-plotattr(:Axis)
-```
-
-Once you acquire the list of attributes, you can either use the aliases of a specific attribute or investigate a specific attribut to print that attribute's aliases and its description.
-
-```sh
-# Specific Attribute Example
-julia> plotattr("size")
-
-size {NTuple{2,Int}}
-windowsize, wsize
-
-(width_px, height_px) of the whole Plot
-Plot attribute,  default: (600, 400)
-```
-
-!!! note
-    Do not forget to enclose the attribute you are attempting to use with double quotes! 
+!!! tip
+    Most of the information on this page is available from your Julia session with the function `plotattr`, e.g. `plotattr(:Series)` to print a list of all series attributes, or `plotattr("ms")` to print the aliases and descriptions of `markersize`.
 
 ---
 
@@ -73,7 +50,7 @@ Passing a tuple to `xticks` (and similarly to `yticks` and `zticks`) changes
 the position of the ticks and the labels:
 
 ```julia
-plot!(xticks = ([0:π:3*π;], ["0", "\pi", "2\pi"]))
+plot!(xticks = ([0:π:3*π;], ["0", "\\pi", "2\\pi"]))
 yticks!([-1:1:1;], ["min", "zero", "max"])
 ```
 
@@ -126,4 +103,3 @@ scatter(y,
     markerstrokestyle = :dot
 )
 ```
-


### PR DESCRIPTION
Here, I added a bit more clarity to the attributes section. Added a concise introduction that includes examples. I changed the formatting just a little bit, because I felt it was confusing and somewhat unclear how to quickly explore documentation from the REPL.