### PR TITLE
add documentation for extra_kwargs in pgfplotsx

### DIFF
--- a/docs/src/backends.md
+++ b/docs/src/backends.md
@@ -27,7 +27,7 @@ Plots.reset_defaults()
             subplot := 2
             line_z := t
             label := false
-            c := :viridis
+            seriescolor := :viridis
             seriestype := surface
             t, t, (x, y) -> x * sin(x) - y * cos(y)
         end

--- a/docs/src/backends.md
+++ b/docs/src/backends.md
@@ -384,8 +384,9 @@ plot(1:5, add = raw"\draw (1,2) rectangle (2,3);", extra_kwargs = :subplot)
 
 Plotly needs to load mathjax to render LaTeX strings, therefore passing extra keywords with `extra_kwargs = :plot` is implemented.
 With that it is possible to pass a header to the extra `include_mathjax` keyword.
+It has the following options:
 
-- `include_mathjax = ""` (default): no mathjax header)
+- `include_mathjax = ""` (default): no mathjax header
 - `include_mathjax = "cdn"` include the standard online version of the header
 - `include_mathjax = "<filename?config=xyz>"` include a user-defined file
 

--- a/docs/src/backends.md
+++ b/docs/src/backends.md
@@ -350,3 +350,16 @@ Saving as `.tikz` file has the advantage, that you can use `\includegraphics` to
 The default LaTeX ouput is intended to be included as a figure in another document and will not compile by itself.
 If you include these figures in another LaTeX document you need to have the correct preamble.
 The preamble of a plot can be shown using `Plots.pgfx_preamble(pl)` or copied from the standalone output.
+
+Using more features of PGFPlotsX is possible by providing the `extra_kwargs`.
+For example changing the ticks of a colormap to be the same as the z axis labels would be possible with
+```julia
+using Plots; pgfplotsx()
+zticks=(π/4*(0:4), [raw"0", raw"\frac{\pi}{4}", raw"\frac{\pi}{2}", raw"\frac{3\pi}{4}", raw"\pi"])
+surface(range(0,5, length=20), range(0,3, length=20), (x, y)->(tmp = atan(- x*y/(1-x^2)); tmp > 0 ? tmp : tmp+π),
+           zticks=zticks, # zaxis labels (same as colormap)
+           extra_kwargs =Dict(:subplot=>Dict( # use extra_kwargs to give arguments directly to PGFPlotsX
+               "colorbar style" => PGFPlotsX.Options( # provide the labels of the colormap
+               "ytick" => "{"*prod(["$(tick)," for tick in zticks[1]])[1:end-1]*"}",
+               "yticklabels" => "{"*prod("\$".*zticks[2].*"\$,")[1:end-1]*"}"),
+               "colormap name" => "viridis"))) # use a colormap supported by pgfplots

--- a/docs/src/backends.md
+++ b/docs/src/backends.md
@@ -171,7 +171,7 @@ LaTeX plotting, based on PGF/TikZ.
 
 ```@example backends
 pgfplotsx(); backendplot() # hide
-
+```
 
 Successor backend of PGFPlots-backend.
 
@@ -338,9 +338,9 @@ Functionality incomplete... I never finished wrapping it, and I don't think it o
 
 ---
 
-# PGFPlotsX
+# LaTeX workflow
 
-### LaTeX workflow
+## PGFPlotsX
 
 To use the native LaTeX output of the `pgfplotsx` backend you can save your plot as a `.tex` or `.tikz` file.
 ```julia
@@ -355,13 +355,56 @@ The default LaTeX ouput is intended to be included as a figure in another docume
 If you include these figures in another LaTeX document you need to have the correct preamble.
 The preamble of a plot can be shown using `Plots.pgfx_preamble(pl)` or copied from the standalone output.
 
-Using more features of PGFPlotsX is possible by providing the [`extra_kwargs`](@id extra_kwargs).
+### Fine tuning
+
+It is possible to use more features of PGFPlotsX via the [`extra_kwargs`](@ref extra_kwargs) mechanism.
+By default it interprets every extra keyword as an option to the `plot` command.
+Setting `extra_kwargs = :subplot` will treat them as an option to the `axis` command and `extra_kwargs = :plot` will be treated as an option to the `tikzpicture` environment.
+
 For example changing the colormap to one that is native to pgfplots can be achieved with the following.
 Like this it is possible to keep the preamble of latex documents clean.
 
 ```@example backends
 using Plots; pgfplotsx()
-pl = surface(range(-3,3, length=30), range(-3,3, length=30),
-        (x, y)->exp(-x^2-y^2), label="",
-        colormap_name = "viridis", extra_kwargs =:subplot)
-        savefig(pl,  "mysurface.tikz")
+surface(range(-3,3, length=30), range(-3,3, length=30),
+        (x, y)->exp(-x^2-y^2),
+        label="",
+        colormap_name = "viridis",
+        extra_kwargs =:subplot)
+```
+
+Further more additional commands or strings can be added via the special `add` keyword.
+This adds a square to a normal line plot:
+
+```@example backends
+plot(1:5, add = raw"\draw (1,2) rectangle (2,3);", extra_kwargs = :subplot)
+```
+
+## Plotly
+
+Plotly needs to load mathjax to render LaTeX strings, therefore passing extra keywords with `extra_kwargs = :plot` is implemented.
+With that it is possible to pass a header to the extra `include_mathjax` keyword.
+
+- `include_mathjax = ""` (default): no mathjax header)
+- `include_mathjax = "cdn"` include the standard online version of the header
+- `include_mathjax = "<filename?config=xyz>"` include a user-defined file
+
+These can also be passed using the `extra_plot_kwargs` keyword.
+
+```@example backends
+plotly()
+plot(1:4, [[1,4,9,16]*10000, [0.5, 2, 4.5, 8]],
+           labels = [L"\alpha_{1c} = 352 \pm 11 \text{ km s}^{-1}";
+                     L"\beta_{1c} = 25 \pm 11 \text{ km s}^{-1}"] |> permutedims,
+           xlabel = L"\sqrt{(n_\text{c}(t|{T_\text{early}}))}",
+           ylabel = L"d, r \text{ (solar radius)}",
+           yformatter = :plain,
+           extra_plot_kwargs = KW(
+               :include_mathjax => "cdn", 
+               :yaxis => KW(:automargin => true),
+               :xaxis => KW(:domain => "auto")
+               ),
+       )
+png("mathjax_plotly") # hide
+```
+![](mathjax_plotly.png)

--- a/docs/src/backends.md
+++ b/docs/src/backends.md
@@ -169,6 +169,10 @@ Primary author: Christof Stocker (@Evizero)
 
 LaTeX plotting, based on PGF/TikZ.
 
+```@example backends
+pgfplotsx(); backendplot() # hide
+
+
 Successor backend of PGFPlots-backend.
 
 Has more features and is still in development otherwise the same.
@@ -351,15 +355,13 @@ The default LaTeX ouput is intended to be included as a figure in another docume
 If you include these figures in another LaTeX document you need to have the correct preamble.
 The preamble of a plot can be shown using `Plots.pgfx_preamble(pl)` or copied from the standalone output.
 
-Using more features of PGFPlotsX is possible by providing the `extra_kwargs`.
-For example changing the ticks of a colormap to be the same as the z axis labels would be possible with
-```julia
+Using more features of PGFPlotsX is possible by providing the [`extra_kwargs`](@id extra_kwargs).
+For example changing the colormap to one that is native to pgfplots can be achieved with the following.
+Like this it is possible to keep the preamble of latex documents clean.
+
+```@example backends
 using Plots; pgfplotsx()
-zticks=(π/4*(0:4), [raw"0", raw"\frac{\pi}{4}", raw"\frac{\pi}{2}", raw"\frac{3\pi}{4}", raw"\pi"])
-surface(range(0,5, length=20), range(0,3, length=20), (x, y)->(tmp = atan(- x*y/(1-x^2)); tmp > 0 ? tmp : tmp+π),
-           zticks=zticks, # zaxis labels (same as colormap)
-           extra_kwargs =Dict(:subplot=>Dict( # use extra_kwargs to give arguments directly to PGFPlotsX
-               "colorbar style" => PGFPlotsX.Options( # provide the labels of the colormap
-               "ytick" => "{"*prod(["$(tick)," for tick in zticks[1]])[1:end-1]*"}",
-               "yticklabels" => "{"*prod("\$".*zticks[2].*"\$,")[1:end-1]*"}"),
-               "colormap name" => "viridis"))) # use a colormap supported by pgfplots
+pl = surface(range(-3,3, length=30), range(-3,3, length=30),
+        (x, y)->exp(-x^2-y^2), label="",
+        colormap_name = "viridis", extra_kwargs =:subplot)
+        savefig(pl,  "mysurface.tikz")

--- a/docs/src/input_data.md
+++ b/docs/src/input_data.md
@@ -240,7 +240,7 @@ If arguments should be passed at multiple layers in the same call or the keyword
 plot(1:5, series_keyword = 5)
 # results in extra_kwargs = Dict( :series => Dict( series_keyword => 5 ) )
 plot(1:5, colormap_width = 6, extra_kwargs = :subplot)
-# results in extra_kwargs = Dict( :subplot => Dict( series_keyword => 5 ) )
+# results in extra_kwargs = Dict( :subplot => Dict( colormap_width = 6 ) )
 plot(1:5, extra_kwargs = Dict( :series => Dict( series_keyword => 5 ), :subplot => Dict( colormap_width => 6 ) ) )
 ```
 

--- a/docs/src/input_data.md
+++ b/docs/src/input_data.md
@@ -226,3 +226,27 @@ batman = Plots.scale(make_batman(), 0.07, 0.07, (0, 0))
 batman = translate(batman, 0.7, 1.23)
 plot!(batman, fillcolor = :black)
 ```
+
+## [Extra keywords](@id extra_kwargs)
+
+There are some features that are very specific to a certain backend or not yet implemented in Plots.
+For these cases it is possible to forward extra keywords to the backend.
+Every keyword that is not a Plots keyword will then be collected in a `extra_kwargs` dictionary.
+
+This dictionary has three layers: `:plot`, `:subplot` and `:series` (default).
+To which layer the keywords get collected can be specified by the `extra_kwargs` keyword.
+If arguments should be passed at multiple layers in the same call or the keyword is already a valid Plots keyword, the `extra_kwargs` dictionary has to be constructed at the call site.
+```julia
+plot(1:5, series_keyword = 5)
+# results in extra_kwargs = Dict( :series => Dict( series_keyword => 5 ) )
+plot(1:5, colormap_width = 6, extra_kwargs = :subplot)
+# results in extra_kwargs = Dict( :subplot => Dict( series_keyword => 5 ) )
+plot(1:5, extra_kwargs = Dict( :series => Dict( series_keyword => 5 ), :subplot => Dict( colormap_width => 6 ) ) )
+```
+
+Refer to the [tracking issue](https://github.com/JuliaPlots/Plots.jl/issues/2648) to see for which backends this feature is implemented.
+Which extra keywords the backend actually handles should be documented in the backend documentation.
+
+!!! warning
+    Using the extra keywords machinery will make your code backend dependent.
+    Only use it for final tweaks. It is clearly a bad idea to use it in recipes.


### PR DESCRIPTION
Should be self explaining.
I added a little example to the `pgfplotsx` section showing how to use `extra_kwargs`.
I am not sure whether I should add a note that for now it is only possible to use this mechanism in the original plot command (ie. if `args` is not empty, see https://github.com/JuliaPlots/Plots.jl/issues/2741#issuecomment-635951442).
Also can you tell me how to add the example plot?
Do I simply need to inset this
``` markdown
```@example backends
pgfplotsx(); backendplot() # hide
```
or do I need to define something more?