### PR TITLE
update link to StatsPlots.jl

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -339,6 +339,6 @@ try. Here's a short list of very usable addons to check out:
 - [PlotThemes.jl](https://github.com/JuliaPlots/PlotThemes.jl) allows you to
   change the color scheme of your plots. For example, `theme(:dark)` adds a
   dark theme.
-- [StatsPlots.jl](https://github.com/JuliaPlots/GGPlots.jl) adds functionality for visualizations of statistical analysis
+- [StatsPlots.jl](https://github.com/JuliaPlots/StatsPlots.jl) adds functionality for visualizations of statistical analysis
 - The [ecosystem page](@ref ecosystem) shows many other packages which have recipes
   and extend Plots.jl's functionality.


### PR DESCRIPTION
the current link in the docs led to the archived GGPlots package. Updated to point to StatsPlots.jl