### PR TITLE
coordinate-update after computing derivatives

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -57,9 +57,12 @@ Base.@kwdef mutable struct Lorenz
 end
 
 function step!(l::Lorenz)
-    dx = l.σ * (l.y - l.x);         l.x += l.dt * dx
-    dy = l.x * (l.ρ - l.z) - l.y;   l.y += l.dt * dy
-    dz = l.x * l.y - l.β * l.z;     l.z += l.dt * dz
+    dx = l.σ * (l.y - l.x)
+    dy = l.x * (l.ρ - l.z) - l.y
+    dz = l.x * l.y - l.β * l.z
+    l.x += l.dt * dx
+    l.y += l.dt * dy
+    l.z += l.dt * dz
 end
 
 attractor = Lorenz()


### PR DESCRIPTION
Coordinates should always be updated after the computation of the derivatives. Else `dy` and `dz` are computed with the values of `l.x` and `l.y` at `t = t + dt`.