### PR TITLE
Removed the outdated reference to juliarc.jl

### DIFF
--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -67,8 +67,8 @@ pyplot()                               # backends are selected with lowercase na
 ```
 
 !!! tip
-    Plots will pick a default backend for you automatically based on what backends are installed. You can override this choice by setting an environment variable in your `~/.juliarc.jl` file: `ENV["PLOTS_DEFAULT_BACKEND"] = "PlotlyJS"`
+    Plots will pick a default backend for you automatically based on what backends are installed. You can override this choice by setting an environment variable in your `~/.julia/config/startup.jl` file (if the file does not exist, create it). To do this, add e.g. the following line of code: `ENV["PLOTS_DEFAULT_BACKEND"] = "PlotlyJS"`
 
 !!! tip
-    You can override standard default values in your `~/.julia/config/startup.jl` file: `PLOTS_DEFAULTS = Dict(:markersize => 10, :legend => false, warn_on_unsupported = false)`
+    You can override standard default values in your `~/.julia/config/startup.jl` file, for example: `PLOTS_DEFAULTS = Dict(:markersize => 10, :legend => false, warn_on_unsupported = false)`
 ---


### PR DESCRIPTION
I changed the reference from juliarc to .julia/config/startup.jl. I also added "To do this, add e.g. the following line of code", in case the previous formulation "by setting an enviroment variable" could be less-than-clear for less tech-savy users. I decided however to keep the previous formulation for techincal correctness, opting for a little more verbose but fitting for a wider audience.

A have also added the parenthesis "(if the file does not exist, create it)" because I know that me and others have googled something related to that file not existing, and that this parenthesis is a good way to short-circuit that confusion. A non-trivial amount of the confusion around the startup-file probably stems from exactly this tip, due to the prevalence of Plots.jl.

I have also added "for example" in the next tip for complete clarity. Together with the previous tip, I think anyone should be able to figure it out both tips completely, and without uncertainty like "Will this work? Am I doing it right?".