### PR TITLE
Autogen unicodeplots and inspectdr

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -76,7 +76,8 @@ end
 @time makedocs(
     format = Documenter.HTML(
         prettyurls = get(ENV, "CI", nothing) == "true",
-        assets = ["assets/favicon.ico"]
+        assets = ["assets/favicon.ico"],
+        ansicolor = true
     ),
     sitename = "Plots",
     authors = "Thomas Breloff",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,8 @@ using Documenter, PlotDocs, Plots, PlotThemes
 ENV["MPLBACKEND"] = "agg"
 
 # Initialize backends
+inspectdr()
+unicodeplots()
 pyplot()
 pgfplotsx()
 plotly()
@@ -59,8 +61,8 @@ const PAGES = Any[
         "Plotly" => "generated/plotly.md",
         "PyPlot" => "generated/pyplot.md",
         "PGFPlotsX" => "generated/pgfplotsx.md",
-        "UnicodePlots" => "examples/unicodeplots.md",
-        "InspectDR" => "examples/inspectdr.md",
+        "UnicodePlots" => "generated/unicodeplots.md",
+        "InspectDR" => "generated/inspectdr.md",
     ],
 ]
 
@@ -68,7 +70,7 @@ generate_attr_markdown()
 generate_supported_markdown()
 generate_graph_attr_markdown()
 generate_colorschemes_markdown()
-for be in (:gr, :plotly, :pyplot, :pgfplotsx)
+for be in (:gr, :plotly, :pyplot, :pgfplotsx, :unicodeplots, :inspectdr)
     generate_markdown(be)
 end
 @time makedocs(

--- a/src/PlotDocs.jl
+++ b/src/PlotDocs.jl
@@ -82,7 +82,7 @@ function generate_markdown(pkgname::Symbol; skip = get(Plots._backend_skips, pkg
         ```@example $pkgname
         Plots.reset_defaults() # hide
         """)
-        if pkgname == :unicodeplots
+        if pkgname ∈ (:unicodeplots, :inspectdr)
             write(md, """
             using Logging # hide
             Logging.disable_logging(Logging.Warn) # hide
@@ -99,11 +99,11 @@ function generate_markdown(pkgname::Symbol; skip = get(Plots._backend_skips, pkg
         if i in (2, 31)
             write(md, "gif(anim, \"anim_$(pkgname)_ex$i.gif\") # hide\n")
         end
-        if pkgname ∈ (:plotly, :plotlyjs)
+        if pkgname ∈ (:plotly, :plotlyjs, :inspectdr)
             write(md, "png(\"$(pkgname)_ex$i\") # hide\n")
         end
         write(md, "```\n")
-        if pkgname ∈ (:plotly, :plotlyjs)
+        if pkgname ∈ (:plotly, :plotlyjs, :inspectdr)
             write(md, "![]($(pkgname)_ex$i.png)\n")
         end
     end

--- a/src/PlotDocs.jl
+++ b/src/PlotDocs.jl
@@ -82,8 +82,19 @@ function generate_markdown(pkgname::Symbol; skip = get(Plots._backend_skips, pkg
         ```@example $pkgname
         Plots.reset_defaults() # hide
         """)
+        if pkgname == :unicodeplots
+            write(md, """
+            using Logging # hide
+            Logging.disable_logging(Logging.Warn) # hide
+            """)
+        end
         for expr in example.exprs
             pretty_print_expr(md, expr)
+        end
+        if pkgname == :unicodeplots
+            write(md, """
+            Plots._show(stdout, MIME("text/plain"), current())  # hide
+            """)
         end
         if i in (2, 31)
             write(md, "gif(anim, \"anim_$(pkgname)_ex$i.gif\") # hide\n")


### PR DESCRIPTION
Should replace [inspectdr.md](https://github.com/JuliaPlots/PlotDocs.jl/blob/master/docs/src/examples/inspectdr.md) and [unicodeplots.md](https://github.com/JuliaPlots/PlotDocs.jl/blob/master/docs/src/examples/unicodeplots.md).

Unicodeplots
------
![unicode-sample](https://user-images.githubusercontent.com/13423344/125144264-97ae0f00-e11d-11eb-8b7a-31ec678545d0.png)

InspectDR
------
![inspectdr-sample](https://user-images.githubusercontent.com/13423344/125144258-9381f180-e11d-11eb-9c0a-d9a5986815e6.png)

