### PR TITLE
Change plotly() to plotlyjs() (savefig removed from PlotlyBase)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,7 @@ ENV["MPLBACKEND"] = "agg"
 
 # Initialize backends
 gr()
-plotly()
+plotlyjs()
 pyplot()
 pgfplotsx()
 unicodeplots()
@@ -59,7 +59,7 @@ const PAGES = Any[
     "Advanced Topics" => ["Internals" => "pipeline.md"],
     "Examples" => [
         "GR" => "generated/gr.md",
-        "Plotly" => "generated/plotly.md",
+        "PlotlyJS" => "generated/plotlyjs.md",
         "PyPlot" => "generated/pyplot.md",
         "PGFPlotsX" => "generated/pgfplotsx.md",
         "UnicodePlots" => "generated/unicodeplots.md",
@@ -72,7 +72,7 @@ generate_attr_markdown()
 generate_supported_markdown()
 generate_graph_attr_markdown()
 generate_colorschemes_markdown()
-for be in (:gr, :plotly, :pyplot, :pgfplotsx, :unicodeplots, :inspectdr, :gaston)
+for be in (:gr, :plotlyjs, :pyplot, :pgfplotsx, :unicodeplots, :inspectdr, :gaston)
     generate_markdown(be)
 end
 ansicolor = get(ENV, "PLOTDOCS_ANSICOLOR", "true") == "true"

--- a/docs/src/backends.md
+++ b/docs/src/backends.md
@@ -127,7 +127,7 @@ as the required javascript is bundled with Plots.  It can create inline plots in
 makes this backend stand out.  From the Julia REPL, it taps into Blink.jl and Electron to plot within a standalone GUI window... also very cool. Also, PlotlyJS supports saving the output to more formats than Plotly, such as EPS and PDF, and thus is the recommended version of Plotly for developing publication-quality figures.
 
 ```@example backends
-plotly(); backendplot(n = 2) # hide
+plotlyjs(); backendplot(n = 2) # hide
 png("backends_plotly") # hide
 ```
 ![](backends_plotly.png)
@@ -161,7 +161,7 @@ These can also be passed using the `extra_plot_kwargs` keyword.
 
 ```@example backends
 using LaTeXStrings
-plotly()
+plotlyjs()
 plot(1:4, [[1,4,9,16]*10000, [0.5, 2, 4.5, 8]],
            labels = [L"\alpha_{1c} = 352 \pm 11 \text{ km s}^{-1}";
                      L"\beta_{1c} = 25 \pm 11 \text{ km s}^{-1}"] |> permutedims,

--- a/docs/src/input_data.md
+++ b/docs/src/input_data.md
@@ -66,7 +66,7 @@ To adress this, you can use `NaN` as a path separator. A call to `plot` would th
 
 ```@example input_data
 using Plots
-plotly()
+plotlyjs()
 
 function rectangle_from_coords(xb,yb,xt,yt)
     [

--- a/docs/src/output.md
+++ b/docs/src/output.md
@@ -64,8 +64,8 @@ A simple table showing which format is supported by which backend
 | html | plotly,  plotlyjs |
 | json | plotly, plotlyjs |
 | pdf  | gr, inspectdr, pgfplotsx, plotlyjs, pyplot |
-| png  | gr, inspectdr, pgfplotsx, plotly, plotlyjs, pyplot |
+| png  | gr, inspectdr, pgfplotsx, plotlyjs, pyplot |
 | ps   | gr, pyplot |
-| svg  | gr, inspectdr, pgfplotsx, plotly, plotlyjs, pyplot |
+| svg  | gr, inspectdr, pgfplotsx, plotlyjs, pyplot |
 | tex  | pgfplotsx |
 | text | hdf5, unicodeplots |

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -116,7 +116,7 @@ done `Pkg.add("GR")`!):
 
 ```@example tutorial
 x = 1:10; y = rand(10, 2) # 2 columns means two lines
-plotly() # Set the backend to Plotly
+plotlyjs() # Set the backend to Plotly
 # This plots into the web browser via Plotly
 plot(x, y, title = "This is Plotted using Plotly")
 png("tutorial_1") # hide


### PR DESCRIPTION
Because of https://github.com/sglyon/PlotlyBase.jl/pull/58, using `plotly()` won't be able to save figures to png anymore.

Fix https://github.com/JuliaPlots/Plots.jl/issues/3703.