### PR TITLE
Fix docs admonition error about compat of RecipesBase 0.9 in recipes

### DIFF
--- a/docs/src/recipes.md
+++ b/docs/src/recipes.md
@@ -464,7 +464,9 @@ Closest candidates are:
   convert(::Type{T}, ::T) where T at essentials.jl:171
   RecipeData(::Any, ::Any) at ~/.julia/packages/RecipesBase/G4s6f/src/RecipesBase.jl:57
 ```
-!!! tip "Use of the `return` keyword in recipes requires RecipesBase 0.9"
+!!! compat "RecipesBase 0.9"
+    Use of the `return` keyword in recipes requires RecipesBase 0.9
+
 This error is encountered if you use the `return` keyword in a recipe, which is not supported in RecipesBase up to v0.8. 
 
 


### PR DESCRIPTION
See the method error with RecipesBase 0.9


http://docs.juliaplots.org/latest/recipes/#MethodError:-Cannot-convert-an-object-of-type-Float64-to-an-object-of-type-RecipeData

![error](https://user-images.githubusercontent.com/52615090/143685593-1b609b3c-46da-44b3-b702-93323a140a80.png)