### PR TITLE
run DemoCards callbacks

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -103,11 +103,11 @@ ansicolor = get(ENV, "PLOTDOCS_ANSICOLOR", "true") == "true"
     authors = "Thomas Breloff",
     pages = PAGES,
 )
-# currently broken
-# foreach(galleries_cb) do cb
-#     # URL redirection for DemoCards-generated gallery
-#     cb()
-# end
+
+foreach(galleries_cb) do cb
+    # URL redirection for DemoCards-generated gallery
+    cb()
+end
 
 deploydocs(
     repo = "github.com/JuliaPlots/PlotDocs.jl.git",


### PR DESCRIPTION
Just rechecked the issue https://github.com/JuliaPlots/PlotDocs.jl/pull/256#issuecomment-1065081466 and then I realized that it's due to incorrect asset paths. If using default theme then it's working okay.

For demos generated by `generate_cards(pkgname...)`, the URL redirection will still be broken. But for new demos added by contributors (#277), the URL redirection will work now.