### PR TITLE
monkey patch `Documenter` to avoid gallery duplicate in search results

### DIFF
--- a/src/PlotDocs.jl
+++ b/src/PlotDocs.jl
@@ -12,8 +12,7 @@ export
     generate_colorschemes_markdown,
     GENDIR
 
-const GENDIR = normpath(@__DIR__, "..", "docs", "src", "generated")
-mkpath(GENDIR)
+const GENDIR = mkpath(normpath(@__DIR__, "..", "docs", "src", "generated"))
 
 const PLOT_DOCS_URL = "https://github.com/JuliaPlots/PlotDocs.jl/blob/master/src/PlotDocs.jl"
 


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/4157.

I went for monkey patching `Documenter` as suggested in https://github.com/JuliaPlots/Plots.jl/issues/2337#issuecomment-645048293.

Not the cleanest solution though (but manageable).

If this works, the next step is to fix https://github.com/JuliaPlots/Plots.jl/issues/2337.