### PR TITLE
rename `UnitfulRecipes` -> `UnitfulExt`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -671,11 +671,11 @@ function main()
                 "Examples" => "GraphRecipes/examples.md",
                 "Attributes" => "generated/graph_attributes.md",
             ],
-            "UnitfulRecipes" => [
-                "Introduction" => "UnitfulRecipes/unitfulrecipes.md",
+            "UnitfulExt" => [
+                "Introduction" => "UnitfulExt/unitfulext.md",
                 "Examples" => [
-                    "Simple" => "generated/unitfulrecipes_examples.md",
-                    "Plots" => "generated/unitfulrecipes_plots.md",
+                    "Simple" => "generated/unitfulext_examples.md",
+                    "Plots" => "generated/unitfulext_plots.md",
                 ]
             ],
             "Overview" => "ecosystem.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -713,17 +713,17 @@ function main()
     end
     @info "copied $n source file(s) to scratch directory `$work`"
 
-    @info "UnitfulRecipes"
-    src_unitfulrecipes = "src/UnitfulRecipes"
-    unitfulrecipes = joinpath(@__DIR__, src_unitfulrecipes)
-    notebooks = joinpath(unitfulrecipes, "notebooks")
+    @info "UnitfulExt"
+    src_unitfulext = "src/UnitfulExt"
+    unitfulext = joinpath(@__DIR__, src_unitfulext)
+    notebooks = joinpath(unitfulext, "notebooks")
 
     execute = true  # set to true for executing notebooks and documenter
     nb = false      # set to true to generate the notebooks
-    for (root, _, files) ∈ walkdir(unitfulrecipes), file ∈ files
+    for (root, _, files) ∈ walkdir(unitfulext), file ∈ files
         last(splitext(file)) == ".jl" || continue
         ipath = joinpath(root, file)
-        opath = replace(ipath, src_unitfulrecipes => "$work/generated") |> splitdir |> first
+        opath = replace(ipath, src_unitfulext => "$work/generated") |> splitdir |> first
         Literate.markdown(ipath, opath; documenter = execute)
         nb && Literate.notebook(ipath, notebooks; execute)
     end

--- a/docs/src/UnitfulExt/unitfulext.md
+++ b/docs/src/UnitfulExt/unitfulext.md
@@ -1,7 +1,8 @@
 *for plotting data with units seamlessly in Julia*
 
-`UnitfulRecipes` provides recipes for plotting figures when using data with [Unitful.jl](https://github.com/PainterQubits/Unitful.jl) units.
+`Plots` provides `Unitful` recipes for plotting figures when using data with [Unitful.jl](https://github.com/PainterQubits/Unitful.jl) units.
 
+NOTE: Since julia `1.9`, the `UnitfulRecipes` module has been renamed to `UnitfulExt` for practical purposes and consistency with package dependencies / weak extensions: this detail (legacy) doesn't have to be known by the end user.
 
 ---
 
@@ -9,7 +10,7 @@
 
 The goal is that if you can plot something with [Plots.jl](https://github.com/JuliaPlots/Plots.jl) then you should be able to plot the same thing with units.
 
-Essentially, `UnitfulRecipes` strips the units of your data and appends them to the corresponding axis labels.
+Essentially, `Unitful` recipes strips the units of your data and appends them to the corresponding axis labels.
 
 Pictures speak louder than words, so we wrote some examples (accessible through the links on the left) for you to get an idea of what this package does or to simply try it out for yourself!
 

--- a/docs/src/UnitfulExt/unitfulext.md
+++ b/docs/src/UnitfulExt/unitfulext.md
@@ -2,7 +2,8 @@
 
 `Plots` provides `Unitful` recipes for plotting figures when using data with [Unitful.jl](https://github.com/PainterQubits/Unitful.jl) units.
 
-NOTE: Since julia `1.9`, the `UnitfulRecipes` module has been renamed to `UnitfulExt` for practical purposes and consistency with package dependencies / weak extensions: this detail (legacy) doesn't have to be known by the end user.
+!!! note
+    Since julia `1.9`, the module formerly known as `UnitfulRecipes` has been moved to a weak dependency called `UnitfulExt`. 
 
 ---
 

--- a/docs/src/UnitfulExt/unitfulext_examples.jl
+++ b/docs/src/UnitfulExt/unitfulext_examples.jl
@@ -9,7 +9,7 @@
 #md #     These examples are available as Jupyter notebooks.
 #md #     You can execute them online with [binder](https://mybinder.org/) or just view them with [nbviewer](https://nbviewer.jupyter.org/) by clicking on the badges above!
 
-# These examples show what `Unitful` recipes is all about.
+# These examples show what `Unitful` recipes are all about.
 
 # First we need to tell Julia we are using Unitful and Plots
 

--- a/docs/src/UnitfulExt/unitfulext_examples.jl
+++ b/docs/src/UnitfulExt/unitfulext_examples.jl
@@ -9,7 +9,7 @@
 #md #     These examples are available as Jupyter notebooks.
 #md #     You can execute them online with [binder](https://mybinder.org/) or just view them with [nbviewer](https://nbviewer.jupyter.org/) by clicking on the badges above!
 
-# These examples show what UnitfulRecipes is all about.
+# These examples show what `Unitful` recipes is all about.
 
 # First we need to tell Julia we are using Unitful and Plots
 
@@ -28,7 +28,7 @@ y2 = 100randn(10)*u"g"
 plot!(y2)
 
 
-# UnitfulRecipes will not allow you to plot with different unit-dimensions, so
+# `Unitful` recipes will not allow you to plot with different unit-dimensions, so
 # ```julia
 # plot!(rand(10)*u"m")
 # ```
@@ -63,7 +63,11 @@ plot([plot(y, ylab="mass", title=repr(s), unitformat=s) for s in (nothing, true,
 
 # `unitformat` can be one of a number of predefined symbols, defined in
 
-URsymbols = keys(UnitfulRecipes.UNIT_FORMATS)
+URsymbols = if isdefined(Base, :get_extension)
+     Base.get_extension(Plots, :UnitfulExt)
+else
+     Plots.UnitfulExt.UNIT_FORMATS
+end |> keys
 
 # which correspond to these unit formats:
 

--- a/docs/src/UnitfulExt/unitfulext_plots.jl
+++ b/docs/src/UnitfulExt/unitfulext_plots.jl
@@ -9,7 +9,7 @@
 #md #     These examples are available as Jupyter notebooks.
 #md #     You can execute them online with [binder](https://mybinder.org/) or just view them with [nbviewer](https://nbviewer.jupyter.org/) by clicking on the badges above!
 
-# These examples were slightly modified from some of [the examples in the Plots.jl documentation](https://github.com/JuliaPlots/Plots.jl/blob/master/src/examples.jl) and can be used as both a tutorial or as a series of test for the UnitfulRecipes module
+# These examples were slightly modified from some of [the examples in the Plots.jl documentation](https://github.com/JuliaPlots/Plots.jl/blob/master/src/examples.jl) and can be used as both a tutorial or as a series of test for the `Unitful` recipes.
 # (they are essentially the same except we have added some units to the data).
 
 # First we need to tell Julia we are using Unitful and Plots

--- a/docs/src/UnitfulExt/unitfulext_plots.jl
+++ b/docs/src/UnitfulExt/unitfulext_plots.jl
@@ -9,7 +9,7 @@
 #md #     These examples are available as Jupyter notebooks.
 #md #     You can execute them online with [binder](https://mybinder.org/) or just view them with [nbviewer](https://nbviewer.jupyter.org/) by clicking on the badges above!
 
-# These examples were slightly modified from some of [the examples in the Plots.jl documentation](https://github.com/JuliaPlots/Plots.jl/blob/master/src/examples.jl) and can be used as both a tutorial or as a series of test for  `Unitful` recipes.
+# These examples were slightly modified from some of [the examples in the Plots.jl documentation](https://github.com/JuliaPlots/Plots.jl/blob/master/src/examples.jl) and can be used as both a tutorial or as a series of test for `Unitful` recipes.
 # (they are essentially the same except we have added some units to the data).
 
 # First we need to tell Julia we are using Unitful and Plots

--- a/docs/src/UnitfulExt/unitfulext_plots.jl
+++ b/docs/src/UnitfulExt/unitfulext_plots.jl
@@ -9,7 +9,7 @@
 #md #     These examples are available as Jupyter notebooks.
 #md #     You can execute them online with [binder](https://mybinder.org/) or just view them with [nbviewer](https://nbviewer.jupyter.org/) by clicking on the badges above!
 
-# These examples were slightly modified from some of [the examples in the Plots.jl documentation](https://github.com/JuliaPlots/Plots.jl/blob/master/src/examples.jl) and can be used as both a tutorial or as a series of test for the `Unitful` recipes.
+# These examples were slightly modified from some of [the examples in the Plots.jl documentation](https://github.com/JuliaPlots/Plots.jl/blob/master/src/examples.jl) and can be used as both a tutorial or as a series of test for  `Unitful` recipes.
 # (they are essentially the same except we have added some units to the data).
 
 # First we need to tell Julia we are using Unitful and Plots

--- a/docs/src/input_data.md
+++ b/docs/src/input_data.md
@@ -149,7 +149,7 @@ PDF graphics can also be added to Plots.jl plots using `load("image.pdf")`. Note
 *Save Gotham*
 
 ```@example input_data
-using Plots
+using RecipesPipeline, Plots
 
 function make_batman()
     p = [(0, 0), (0.5, 0.2), (1, 0), (1, 2),  (0.3, 1.2), (0.2, 2), (0, 1.7)]
@@ -163,7 +163,7 @@ function make_batman()
             map(BezierCurve([p[i], m[i], p[i + 1]]), range(0, 1, length = 30))
         )
     end
-    x, y = Plots.unzip(Tuple.(pts))
+    x, y = RecipesPipeline.unzip(Tuple.(pts))
     Shape(vcat(x, -reverse(x)), vcat(y, reverse(y)))
 end
 
@@ -181,7 +181,7 @@ plt = plot(
 ```@example input_data
 # create an ellipse in the sky
 pts = Plots.partialcircle(0, 2π, 100, 0.1)
-x, y = Plots.unzip(pts)
+x, y = RecipesPipeline.unzip(pts)
 x = 1.5x .+ 0.7
 y .+= 1.3
 pts = collect(zip(x, y))

--- a/docs/src/input_data.md
+++ b/docs/src/input_data.md
@@ -149,7 +149,7 @@ PDF graphics can also be added to Plots.jl plots using `load("image.pdf")`. Note
 *Save Gotham*
 
 ```@example input_data
-using RecipesPipeline, Plots
+using Plots
 
 function make_batman()
     p = [(0, 0), (0.5, 0.2), (1, 0), (1, 2),  (0.3, 1.2), (0.2, 2), (0, 1.7)]
@@ -163,7 +163,7 @@ function make_batman()
             map(BezierCurve([p[i], m[i], p[i + 1]]), range(0, 1, length = 30))
         )
     end
-    x, y = RecipesPipeline.unzip(Tuple.(pts))
+    x, y = Plots.unzip(Tuple.(pts))
     Shape(vcat(x, -reverse(x)), vcat(y, reverse(y)))
 end
 
@@ -181,7 +181,7 @@ plt = plot(
 ```@example input_data
 # create an ellipse in the sky
 pts = Plots.partialcircle(0, 2π, 100, 0.1)
-x, y = RecipesPipeline.unzip(pts)
+x, y = Plots.unzip(pts)
 x = 1.5x .+ 0.7
 y .+= 1.3
 pts = collect(zip(x, y))


### PR DESCRIPTION
I think this change is consistent with the extensions introduced in https://github.com/JuliaPlots/Plots.jl/pull/4649.

The module name is in the end an implementation detail.

Fixes docs build failure following merge of https://github.com/JuliaPlots/Plots.jl/pull/4649.