### PR TITLE
Up to 3pi in ticks but only 2pi in labels

### DIFF
--- a/docs/src/attributes.md
+++ b/docs/src/attributes.md
@@ -70,7 +70,7 @@ Passing a tuple to `xticks` (and similarly to `yticks` and `zticks`) changes
 the position of the ticks and the labels:
 
 ```julia
-plot!(xticks = ([0:π:3*π;], ["0", "\\pi", "2\\pi"]))
+plot!(xticks = ([0:π:2*π;], ["0", "\\pi", "2\\pi"]))
 yticks!([-1:1:1;], ["min", "zero", "max"])
 ```
 


### PR DESCRIPTION
I honestly don't know if this per purpose, but I was a little confused. Before there were four ticks but only three tick labels. If this was correct please forgive me for this PR.

Another solution (again if it was a typo before) 
`plot!(xticks = ([0:π:3*π;], ["0", "\\pi", "2\\pi, 3\\pi"]))`